### PR TITLE
Feature/#16 mu create

### DIFF
--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -1,0 +1,43 @@
+class MusicsController < ApplicationController
+  skip_before_action :require_login
+  def search
+    if params[:search].present?
+      search_results = RSpotify::Track.search(params[:search])
+      @musics = search_results.first(20).map do |track|
+        {
+          id: track.id,
+          title: track.name,
+          artist: track.artists.first.name,
+        }
+      end
+    else
+      @musics = []  # 検索クエリがない場合は空の結果を返す
+    end
+
+    render :new
+  end
+
+
+  # GET /musics/new
+  def new
+    @music = Music.new
+  end
+
+  # POST /musics or /musics.json
+  def create
+    @music = current_user.musics.build(music_params)
+      if @music.save
+        flash[:success] = "MUを作成しました！"
+        redirect_to root_path
+      else
+        flash.now[:error] = "MUの作成に失敗しました"
+        render :new, status: :unprocessable_entity
+      end
+  end
+
+  private
+
+  def music_params
+    params.permit(:artist, :spotify_track_id, :title)
+  end
+end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -1,0 +1,2 @@
+class Music < ApplicationRecord
+end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -1,2 +1,5 @@
 class Music < ApplicationRecord
+  belongs_to :user
+
+  validates :title, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :musics, dependent: :destroy
+
   validates :name, presence: true, length: { maximum: 20 }
   validates :email, presence: true, uniqueness: true
   validates :password, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,9 +17,9 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
     <%= render 'shared/flash_messages'%>
-    <div class="container mx-auto">
+
       <%= yield %>
-    </div>
+
     <%= render 'shared/footer'%>
   </body>
 </html>

--- a/app/views/musics/_search_form.html.erb
+++ b/app/views/musics/_search_form.html.erb
@@ -1,0 +1,7 @@
+<div class="mx-auto">
+  <h3>曲名orアーティスト名で検索</h3>
+  <%= form_with url: search_musics_path, method: :get, local: true do |form| %>
+    <%= form.text_field :search %>
+    <%= form.submit '曲名検索', name: nil, class: "btn btn-sm btn-primary" %>
+  <% end %>
+</div>

--- a/app/views/musics/_search_result.html.erb
+++ b/app/views/musics/_search_result.html.erb
@@ -1,0 +1,16 @@
+<div class="mt-4">
+  <h2 class="text-center font-bold text-primary mb-2">検索結果</h2>
+  <div class="flex flex-wrap justify-center">
+    <% musics.each do |music| %>
+      <div class="p-1 my-2 border-radius">
+        <iframe src="https://open.spotify.com/embed/track/<%= music[:id] %>" width="100%" height="80" frameborder="0" style="border-radius:12px" allowtransparency="true" allow="encrypted-media"></iframe>
+        <%= form_with url: musics_path, data: {turbo_method: :post, turbo_confirm: "このMUを作成しますか？"} do |form| %>
+          <%= form.hidden_field :spotify_track_id, value: music[:id] %>
+          <%= form.hidden_field :artist, value: music[:artist] %>
+          <%= form.hidden_field :title, value: music[:title] %>
+          <%= form.submit 'MUをつくる！', class: "btn btn-sm btn-outline btn-primary p-3" %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/musics/new.html.erb
+++ b/app/views/musics/new.html.erb
@@ -1,0 +1,6 @@
+<div class="flex flex-col mx-auto">
+  <%= render 'search_form' %>
+  <% if @musics.present? %>
+    <%= render 'search_result', musics: @musics %>
+  <% end %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,6 +6,6 @@
         <%= link_to "一覧", "#", class: "btn btn-primary mr-2"%>
         <%= link_to "作成", "#", class: "btn btn-primary mr-2"%>
         <%= link_to current_user.name, "#", class: "btn btn-secondary"%>
-        <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }%>
+        <%= link_to "LO", logout_path, data: { turbo_method: :delete }%>
     </nav>
 </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Rails.application.routes.draw do
   root "static_pages#top"
   resources :users, only: %i[new create]
+  resources :musics, only: %i[new create] do
+    collection do
+      get :search
+    end
+  end
   get 'login', to: 'user_sessions#new', :as => :login
   post 'login', to: "user_sessions#create"
   delete 'logout', to: 'user_sessions#destroy', :as => :logout

--- a/db/migrate/20240321230554_create_musics.rb
+++ b/db/migrate/20240321230554_create_musics.rb
@@ -1,0 +1,11 @@
+class CreateMusics < ActiveRecord::Migration[7.1]
+  def change
+    create_table :musics do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.string :spotify_track_id
+      t.string :artist
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_011054) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_21_230554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "musics", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.string "spotify_track_id"
+    t.string "artist"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_musics_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -25,4 +35,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_011054) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "musics", "users"
 end


### PR DESCRIPTION
## 概要
MU作成機能の実装
## 変更内容
-  musicモデル作成
- バリデーション設定
- ビュー作成(new, _search_form, _search_result)
- コントローラー作成
- ルーティング設定
## 備考
- 実装の用意性と手軽に試聴できるユーザビリティから、Spotify埋め込みで実装（当初はジャケット写真などのデータも保存して表示する予定だった）。また、見た目もカラフルになる。
- 検索時の候補は20曲にしているが、表示に時間がかかっているため検討の余地あり。

close#16