### PR TITLE
Feature/#23 memory edit

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -10,6 +10,21 @@ class MemoriesController < ApplicationController
     end
   end
 
+  def edit
+    @memory = Memory.find(params[:id])
+  end
+
+  def update
+    memory = Memory.find(params[:id])
+    if memory.update(params.require(:memory).permit(:body)) #汚いので改善したい。
+      flash[:success] = "メモリーを更新しました"
+      redirect_to music_path(memory.music)
+    else
+      flash.now[:erorr] = "メモリーの更新に失敗しました"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def memory_params

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: memory, url: [music, memory], data: { turbo_method: :post } do |form| %>
-  <%= render 'shared/error_messages', object: form.object %>
+  <%#= render 'shared/error_messages', object: form.object %><!-- エラーが出るためコメントアウト　-->
   <%= form.text_area :body, class: "w-full h-auto my-2 text-base" %>
   <%= form.submit "追加する", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -2,6 +2,12 @@
   <div class="bg-base-300 border-bg-100 p-3">
     <div class="badge badge-primary">タグ</div>
     <%= simple_format(memory.body) %>
+    <div class="object-right-top">
+    <% if logged_in? && current_user.own?(memory.music) %>
+      <%= link_to "削除", memory_path(memory), class: "btn btn-sm btn-error float-right" %>
+      <%= link_to "編集", edit_memory_path(memory), class: "btn btn-sm btn-secondary mx-2 float-right" %>
+    <% end %>
+    </div>
     <p class="text-right"><%= l memory.created_at, format: :long %></p>
   </div>
 </div>

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -1,0 +1,5 @@
+<%= form_with model: @memory, local: true do |form| %>
+  <%#= render 'shared/error_messages', object: form.object %><!-- エラーが出るためコメントアウト　-->
+  <%= form.text_area :body, class: "w-full h-auto my-2 text-base"%>
+  <%= form.submit "編集完了", class: "btn btn-primary" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     collection do
       get :search
     end
-    resources :memories, only: %i[create update destroy]
+    resources :memories, only: %i[create edit update destroy], shallow: true
   end
   get 'login', to: 'user_sessions#new', :as => :login
   post 'login', to: "user_sessions#create"


### PR DESCRIPTION
## 概要
メモリー編集機能の追加
## 内容
- メモリーのルーティングにshallowオプション追加。
- memories_controllerにedit, updateアクションを追加。
- _memory.html.erbに編集ボタンと削除ボタンを追加
- editのビューを作成
## 備考
メモリーのbodyを空欄で編集完了ボタンを押すとobjectがnilになってしまい、エラーメッセージの呼び出し部分の<% if object.errors.any? %>がNoMethodErrorになってしまう。
解決方法がわからないため、差し当たってはコメントアウトした。

close #23 