### PR TITLE
Feature/#37 tag

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -35,6 +35,6 @@ class MemoriesController < ApplicationController
   private
 
   def memory_params
-    params.require(:memory).permit(:body).merge(music_id: params[:music_id])
+    params.require(:memory).permit(:body, tag_ids: []).merge(music_id: params[:music_id])
   end
 end

--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -43,7 +43,7 @@ class MusicsController < ApplicationController
   def show
     @music = Music.find(params[:id])
     @memory = Memory.new
-    @memories = @music.memories.order(created_at: :desc)
+    @memories = @music.memories.includes(:tags).order(created_at: :desc)
   end
 
   def destroy

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -1,5 +1,7 @@
 class Memory < ApplicationRecord
   belongs_to :music, touch: true
+  has_many :memory_tags, dependent: :destroy
+  has_many :tags, through: :memory_tags
 
   validates :body, presence: true, length: { maximum: 65_535 }
 end

--- a/app/models/memory_tag.rb
+++ b/app/models/memory_tag.rb
@@ -1,0 +1,6 @@
+class MemoryTag < ApplicationRecord
+  belongs_to :memory
+  belongs_to :tag
+
+  validates :tag_id, uniqueness: { scope: :memory_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,4 @@
+class Tag < ApplicationRecord
+  has_many :memory_tags, dependent: :destroy
+  has_many :memories, through: :memory_tags
+end

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -1,5 +1,11 @@
 <%= form_with model: memory, url: [music, memory], data: { turbo_method: :post } do |form| %>
   <%#= render 'shared/error_messages', object: form.object %><!-- エラーが出るためコメントアウト　-->
+  <% Tag.all.each do |tag| %>
+    <div class="btn btn-sm btn-outline btn-primary">
+      <%= form.check_box :tag_ids, { multiple: true }, tag.id, nil %>
+      <%= tag.name %>
+    </div>
+  <% end %>
   <%= form.text_area :body, class: "w-full h-auto my-2 text-base" %>
   <%= form.submit "追加する", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -1,12 +1,15 @@
 <div class="bg-base-100 mb-4">
   <div class="bg-base-300 border-bg-100 p-3">
-    <div class="badge badge-primary">タグ</div>
+    <% memory.tags.each do |tag| %>
+      <div class="badge badge-primary"><%= tag.name %></div>
+    <% end %>
+
     <%= simple_format(memory.body) %>
     <div class="object-right-top">
-    <% if logged_in? && current_user.own?(memory.music) %>
-      <%= link_to "削除", memory_path(memory), data: { turbo_method: :delete, turbo_confirm: "本当にこのメモリーを削除しますか？" }, class: "btn btn-sm btn-error float-right" %>
-      <%= link_to "編集", edit_memory_path(memory), class: "btn btn-sm btn-secondary mx-2 float-right" %>
-    <% end %>
+      <% if logged_in? && current_user.own?(memory.music) %>
+        <%= link_to "削除", memory_path(memory), data: { turbo_method: :delete, turbo_confirm: "本当にこのメモリーを削除しますか？" }, class: "btn btn-sm btn-error float-right" %>
+        <%= link_to "編集", edit_memory_path(memory), class: "btn btn-sm btn-secondary mx-2 float-right" %>
+      <% end %>
     </div>
     <p class="text-right"><%= l memory.created_at, format: :long %></p>
   </div>

--- a/db/migrate/20240326024812_create_tags.rb
+++ b/db/migrate/20240326024812_create_tags.rb
@@ -1,0 +1,8 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240326024859_create_memory_tags.rb
+++ b/db/migrate/20240326024859_create_memory_tags.rb
@@ -1,0 +1,9 @@
+class CreateMemoryTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :memory_tags do |t|
+      t.references :memory, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_24_092701) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_26_024859) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_24_092701) do
     t.index ["music_id"], name: "index_memories_on_music_id"
   end
 
+  create_table "memory_tags", force: :cascade do |t|
+    t.bigint "memory_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["memory_id"], name: "index_memory_tags_on_memory_id"
+    t.index ["tag_id"], name: "index_memory_tags_on_tag_id"
+  end
+
   create_table "musics", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", null: false
@@ -30,6 +39,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_24_092701) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_musics_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -44,5 +59,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_24_092701) do
   end
 
   add_foreign_key "memories", "musics"
+  add_foreign_key "memory_tags", "memories"
+  add_foreign_key "memory_tags", "tags"
   add_foreign_key "musics", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,15 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+tag_mappings = {
+  1 => '思い出',
+  2 => '推しポイント',
+  3 => '好きな歌詞',
+  4 => 'ライブ',
+  5 => '推し活',
+  6 => '主題歌',
+  7 => 'カラオケ',
+  8 => '考察',
+  9 => '演奏'
+}
+
+tag_mappings.each do |id, name|
+  Tag.create!(id: id, name: name)
+end


### PR DESCRIPTION
## 概要
メモリー作成時にタグを選択できるように実装。
タグはユーザーが作るのではなくseedファイルであらかじめ用意する。
タグは複数選択可能。
各メモリーに選択したタグが表示される。
## 内容
 - tagsテーブル、memory_tagsテーブルを作成
 - タグのseedファイル作成、マイグレーション
 - メモリーのフォームにタグを選択できるボタンを追加
-  タグを保存できるようコントローラーを編集
 - メモリーのタグをメモリーの上に表示させる
## 備考
タグを選択ボタンにしたかったが、ボタンの中のチェックボックスにチェックを入れないといけない仕様になっているのでできれば改善したい。
