### PR TITLE
Fix/#80 edit entrypoint seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,5 +11,5 @@ tag_mappings = {
 }
 
 tag_mappings.each do |id, name|
-  Tag.create!(id: id, name: name)
+  Tag.find_or_create_by!(id: id, name: name)
 end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,5 @@ yarn install
 yarn build
 bundle exec rake assets:precompile
 bundle exec rails db:migrate
+bundle exec rails db:seed
 exec "$@"


### PR DESCRIPTION
## 概要
entrypoint.shにbundle exec rails db:seedを追加し忘れたため、タグのデータが入っていなかった。
seedファイルのタグ作成がcreate!でやっていたため、重複が起こるとエラーになってデプロイ失敗する。
find_or_create_by!に変更。

close #80 