### PR TITLE
Fix/#82 fix puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,3 +35,5 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 plugin :tmp_restart
 
 preload_app!
+
+workers ENV.fetch("WEB_CONCURRENCY") { 4 }

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,3 +33,5 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+preload_app!


### PR DESCRIPTION
## 概要
RAMメモリの使用量が500Mで前後で推移しており、頻繁に制限を超えてしまうのでpumaの設定をいくつか試してみた。
## 内容
- preload_app!追加
- ワーカーを8⇒4に
## 結果
50M程度減っている気もするが劇的な効果は見られず、まだ判断しきれない。
また後で他の方法を考える。

close #82 