### PR TITLE
Feature/#25 comment create

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,18 @@
+class CommentsController < ApplicationController
+  def create
+    comment = current_user.comments.build(comment_params)
+    if comment.save
+      flash[:success] = "コメントを追加しました"
+      redirect_to music_path(comment.music)
+    else
+      flash[:error] = "コメントを追加できませんでした"
+      redirect_to music_path(comment.music)
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body).merge(music_id: params[:music_id])
+  end
+end

--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -44,6 +44,8 @@ class MusicsController < ApplicationController
     @music = Music.find(params[:id])
     @memory = Memory.new
     @memories = @music.memories.includes(:tags).order(created_at: :desc)
+    @comment = Comment.new
+    @comments = @music.comments.includes(:user).order(created_at: :asc)
   end
 
   def destroy

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,2 @@
+class Comment < ApplicationRecord
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,2 +1,5 @@
 class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :music
+  validates :body, presence: true, length: { maximum: 65_535 }
 end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -1,6 +1,7 @@
 class Music < ApplicationRecord
   belongs_to :user
   has_many :memories, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   validates :title, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :musics, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 20 }
   validates :email, presence: true, uniqueness: true

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,10 @@
+<div class="bg-base-100 mb-4">
+  <div class="bg-base-300 border-bg-100 p-3">
+      <div class="btn btn-link btn-sm">
+      <%= link_to comment.user.name, "#"%>
+      </div>
+    <%= simple_format(comment.body) %>
+
+    <p class="text-right"><%= l comment.created_at, format: :long %></p>
+  </div>
+</div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,5 @@
+<%= form_with model: comment, url: [music, comment], data: { turbo_method: :post } do |form| %>
+  <%= render 'shared/error_messages', object: form.object %><!-- エラーが出るためコメントアウト　-->
+  <%= form.text_area :body, class: "w-full h-auto my-2 text-base" %>
+  <%= form.submit "追加する", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/musics/show.html.erb
+++ b/app/views/musics/show.html.erb
@@ -35,7 +35,19 @@
 
 <!-- コメント -->
       <input type="radio" name="my_tabs_2" role="tab" class="tab" aria-label="コメント" />
-      <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">コメント</div>
+      <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
+        <% if logged_in? %>
+          <details class="dropdown">
+            <summary class="btn btn-sm btn-outline btn-success">コメントを追加する</summary>
+            <div class="p-2 w-auto" >
+              <%= render 'comments/form', { music: @music, comment: @comment } %>
+            </div>
+          </details>
+        <% else %>
+          <div class="btn btn-warning">コメントにはログインが必要です！</div>
+        <% end %>
+        <%= render @comments %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get :search
     end
     resources :memories, only: %i[create edit update destroy], shallow: true
+    resources :comments, only: %i[create update destroy], shallow: true
   end
   get 'login', to: 'user_sessions#new', :as => :login
   post 'login', to: "user_sessions#create"

--- a/db/migrate/20240327015906_create_comments.rb
+++ b/db/migrate/20240327015906_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :comments do |t|
+      t.text :body, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :music, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_26_024859) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_27_015906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "music_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["music_id"], name: "index_comments_on_music_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "memories", force: :cascade do |t|
     t.bigint "music_id", null: false
@@ -58,6 +68,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_26_024859) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "comments", "musics"
+  add_foreign_key "comments", "users"
   add_foreign_key "memories", "musics"
   add_foreign_key "memory_tags", "memories"
   add_foreign_key "memory_tags", "tags"


### PR DESCRIPTION
## 概要
コメント投稿・一覧機能の追加。
## 内容
- commentモデル追加
- アソシエーション、バリデーション追加
- ルーティング設定
- musicsコントローラーのshowアクションにcomment追加、一覧用の追記
- commentsコントローラーの追加
- musics/showビューにフォームとバーシャルのレンダリングを追加
- コメントフォームを追加
- コメントパーシャルを追加
## 備考
余力があれば返信機能も作りたい。
daisyUIのタブのデザインの修正がうまくいかず、タブラベルがはみ出してしまう。
できればコメント追加後はコメントのタブを開いた状態で表示できるようにしたい。

close #25 