### PR TITLE
Feature/#27 mu latest memory

### DIFF
--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -2,7 +2,7 @@ class MusicsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
 
   def index
-    @musics = Music.includes(:user).order(updated_at: :desc)
+    @musics = Music.includes(:user, memories: :tags).order(updated_at: :desc)
   end
 
   def search

--- a/app/views/musics/_music.html.erb
+++ b/app/views/musics/_music.html.erb
@@ -1,5 +1,5 @@
 
-<div class="p-3">
+<div class="flex p-3">
   <div class="bg-base-100">
     <iframe src="https://open.spotify.com/embed/track/<%= music.spotify_track_id %>" width="100%" height="80" frameborder="0" style="border-radius:12px" allowtransparency="true" allow="encrypted-media"></iframe>
     <div class="p-2 bg-base-300">
@@ -9,9 +9,20 @@
       <% end %>
       <p><%= link_to music.user.name, "#" %></p>
       <div class="justify-end">
-        <p>最新のメモリー</p>
-        <div class="badge badge-secondary">メモリーのタグ</div>
-        <p>てすとてすとてすとてすと</p>
+        <% latest_memory = music.memories.order(created_at: :desc).first %>
+        <% if latest_memory %>
+          <% latest_memory.tags.each do |tag| %>
+            <div class="badge badge-primary">
+              <%= tag.name %>
+            </div>
+          <% end %>
+
+          <% if latest_memory.body.size >= 19 %>
+            <p><%= latest_memory.body.slice(0..19) %>...</p>
+          <% else %>
+            <p><%= latest_memory.body %></p>
+          <% end %>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
MU一覧画面に最新のメモリーとタグを表示させる
## 内容
- indexアクションのincludesにmemories: :tagsを追加
- musicパーシャルに最新のメモリーとタグを表示する
## 備考
- パーシャルビューに最新のメモリーを取得して最初の19文字を切り取るロジックを書いているため要改善。
- N+1問題が発生し、大量のSQLクエリが発行されているため要改善。
- タグが多いとレイアウトが崩れるのでタグは3個までに制限する。

close #27 