### PR TITLE
add: タグの選択をを3つまでに制限するバリデーションを追加

### DIFF
--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -4,4 +4,14 @@ class Memory < ApplicationRecord
   has_many :tags, through: :memory_tags
 
   validates :body, presence: true, length: { maximum: 65_535 }
+  validate :validate_tag_count
+
+  private
+
+  def validate_tag_count
+    max_tags = 3
+    if tag_ids.count > max_tags
+      errors.add(:base, "選択できるタグは#{max_tags}個までです")
+    end
+  end
 end

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -1,5 +1,6 @@
 <%= form_with model: memory, url: [music, memory], data: { turbo_method: :post } do |form| %>
   <%#= render 'shared/error_messages', object: form.object %><!-- エラーが出るためコメントアウト　-->
+  <p>タグは3つまで選べます。</p>
   <% Tag.all.each do |tag| %>
     <div class="btn btn-sm btn-outline btn-primary">
       <%= form.check_box :tag_ids, { multiple: true }, tag.id, nil %>


### PR DESCRIPTION
## 概要
タグの選択をを3つまでに制限するバリデーションを追加。
## 備考
エラーメッセージを表示できない問題は依然解決せず。

close #87 