### PR TITLE
Feature/#28 mu levelup

### DIFF
--- a/app/models/level_setting.rb
+++ b/app/models/level_setting.rb
@@ -1,0 +1,2 @@
+class LevelSetting < ApplicationRecord
+end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -6,6 +6,7 @@ class Memory < ApplicationRecord
   validates :body, presence: true, length: { maximum: 65_535 }
   validate :validate_tag_count
 
+  after_commit :update_music_exp
   private
 
   def validate_tag_count
@@ -13,5 +14,14 @@ class Memory < ApplicationRecord
     if tag_ids.count > max_tags
       errors.add(:base, "選択できるタグは#{max_tags}個までです")
     end
+  end
+
+  private
+
+  def update_music_exp
+    # musicに紐づくすべてのmemoryのbodyの文字数を合計
+    total_exp = self.music.memories.sum { |memory| memory.body.length }
+    # 合計値をmusicのexpとして保存
+    self.music.update(experience_point: total_exp)
   end
 end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -4,4 +4,13 @@ class Music < ApplicationRecord
   has_many :comments, dependent: :destroy
 
   validates :title, presence: true
+
+  after_update :update_level
+
+  private
+
+  def update_level
+    current_level = LevelSetting.where('threshold <= ?', self.experience_point).order(level: :desc).first
+    self.update_column(:level, current_level.level) if current_level.present?
+  end
 end

--- a/app/views/musics/_music.html.erb
+++ b/app/views/musics/_music.html.erb
@@ -3,9 +3,10 @@
   <div class="bg-base-100">
     <iframe src="https://open.spotify.com/embed/track/<%= music.spotify_track_id %>" width="100%" height="80" frameborder="0" style="border-radius:12px" allowtransparency="true" allow="encrypted-media"></iframe>
     <div class="p-2 bg-base-300">
-      <%= link_to music_path(music), class: "hover:text-blue-600" do %>
+      <%= link_to music_path(music), class: "link hover:text-blue-600" do %>
         <p><%=  music.title %></p>
         <p><%=  music.artist %></p>
+        <p class="text-right"><%= "Lv. #{music.level}"%></p>
       <% end %>
       <p><%= link_to music.user.name, "#" %></p>
       <div class="justify-end">
@@ -17,8 +18,8 @@
             </div>
           <% end %>
 
-          <% if latest_memory.body.size >= 19 %>
-            <p><%= latest_memory.body.slice(0..19) %>...</p>
+          <% if latest_memory.body.size >= 16 %>
+            <p><%= latest_memory.body.slice(0..16) %>...</p>
           <% else %>
             <p><%= latest_memory.body %></p>
           <% end %>

--- a/app/views/musics/show.html.erb
+++ b/app/views/musics/show.html.erb
@@ -3,6 +3,8 @@
     <p class="text-2xl font-bold"><%= @music.user.name%></p>
     <p class="text-2xl"><%=  @music.title %><%= %></p>
     <p class="text-lg"><%=  @music.artist %></p>
+    <%= @music.experience_point%>
+    <p class="text-2xl text-right"><%= "Lv. #{@music.level}"%></p>
     <% if logged_in? && current_user.own?(@music) %>
       <%= link_to "削除", music_path(@music), data: { turbo_method: :delete, turbo_confirm: "本当にこのMUを削除しますか？追加したメモリーも削除されます。"}, class: "btn btn-sm btn-error float-right"%>
     <% end %>

--- a/db/migrate/20240328071729_add_level_to_musics.rb
+++ b/db/migrate/20240328071729_add_level_to_musics.rb
@@ -1,0 +1,6 @@
+class AddLevelToMusics < ActiveRecord::Migration[7.1]
+  def change
+    add_column :musics, :experience_point, :integer, default: 0
+    add_column :musics, :level, :integer, default: 1
+  end
+end

--- a/db/migrate/20240328080242_create_level_settings.rb
+++ b/db/migrate/20240328080242_create_level_settings.rb
@@ -1,0 +1,9 @@
+class CreateLevelSettings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :level_settings do |t|
+      t.integer :level
+      t.integer :threshold
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_27_015906) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_28_071729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_27_015906) do
     t.string "artist"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "experience_point", default: 0
+    t.integer "level", default: 1
     t.index ["user_id"], name: "index_musics_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_28_071729) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_28_080242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_28_071729) do
     t.datetime "updated_at", null: false
     t.index ["music_id"], name: "index_comments_on_music_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "level_settings", force: :cascade do |t|
+    t.integer "level"
+    t.integer "threshold"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "memories", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,3 +13,14 @@ tag_mappings = {
 tag_mappings.each do |id, name|
   Tag.find_or_create_by!(id: id, name: name)
 end
+
+LevelSetting.find_or_create_by!(level: 1, threshold: 0)
+prev_threshold = 0
+
+# 各レベルの閾値を設定
+(2..100).each do |level|
+  # 次のレベルに必要なexpを1ずつ上げる
+  threshold = prev_threshold + level + 3
+  LevelSetting.find_or_create_by!(level: level, threshold: threshold)
+  prev_threshold = threshold
+end


### PR DESCRIPTION
## 概要
メモリー更新・削除時に文字数に応じてレベルアップorダウンする機能の追加。
## 内容
- musicsテーブルにexperience_point、levelカラムを追加。
- memoryモデルの更新時に、musicテーブルののexperience_pointが更新されるコールバックメソッドを追加。
- LevelSettingモデル作成。
- レベルと閾値（threshold）の設定をseedファイルに追加。
- musicモデルの更新時（レベル更新時）に該当の閾値に対応するレベルに更新されるコールバックメソッドを追加。
- ビューにレベルを表示させる。
## 備考
すでに作成済みのMUも更新しないとレベル1のままなので全データを更新することができるならやりたい。
経験値テーブルはシンプルに1レベルごとに次に上がるための文字数が1字ずつ増えていくように作ったが、余裕があればもっとこだわりたい。

close #28 