### PR TITLE
add: ソート機能追加

### DIFF
--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -3,7 +3,8 @@ class MusicsController < ApplicationController
 
   def index
     @q = Music.ransack(params[:q])
-    @musics = @q.result(distinct: true).includes(:user, memories: :tags).order(updated_at: :desc).page(params[:page])
+    @q.sorts = ['updated_at desc'] unless params[:sorts].present?
+    @musics = @q.result(distinct: true).includes(:user, memories: :tags).page(params[:page])
   end
 
   def search

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -24,4 +24,16 @@ class Memory < ApplicationRecord
     # 合計値をmusicのexpとして保存
     self.music.update(experience_point: total_exp)
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["body", "created_at", "id", "id_value", "music_id", "updated_at"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(music)
+  end
+
+  def self.ransortable_attributes(auth_object = nil)
+    %w(memories_count)
+  end
 end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -7,6 +7,20 @@ class Music < ApplicationRecord
 
   after_update :update_level
 
+  ransacker :memories_count do
+    query = <<-SQL
+    (SELECT
+       COUNT(memories.music_id)
+     FROM
+       memories
+     WHERE
+       memories.music_id = music.id
+     GROUP BY
+       memories.music_id)
+  SQL
+  Arel.sql(query)
+  end
+
   private
 
   def update_level
@@ -15,10 +29,14 @@ class Music < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    %w(title artist memories_body) # 検索可能な属性のリストを定義
+    %w(title artist) # 検索可能な属性のリストを定義
   end
 
   def self.ransackable_associations(auth_object = nil)
     %w(memories comments tags users)
+  end
+
+  def self.ransortable_attributes(auth_object = nil)
+    %w(level updated_at memories_count)
   end
 end

--- a/app/views/musics/index.html.erb
+++ b/app/views/musics/index.html.erb
@@ -1,10 +1,16 @@
 <% content_for(:title, t('.title')) %>
 <h1 class="text-center py-4 text-2xl">みんなのMU</h1>
 <div class="flex justify-center mb-6">
-  <div class="p-10">
+  <div class="mr-4">
     <%= search_form_for @q do |f| %>
       <%= f.search_field :title_or_artist_cont, class: "w-300 py-1 px-3 mr-3", placeholder: "曲名orアーティスト" %>
       <%= f.submit "検索", class: "btn btn-sm btn-primary" %>
+    <% end %>
+  </div>
+  <div>
+    <%= search_form_for @q do |f| %>
+      <%= f.select(:sorts, {'レベル高い順': 'level desc', '更新新しい順': 'updated_at desc', '更新古い順': 'updated_at asc'}, { include_blank: '選択してください' }, class: "w-300 py-1 px-3 mr-3") %>
+      <%= f.submit "並び替え", class: "btn btn-sm btn-primary" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
MUソート機能追加
レベル高い順、更新新しい順・古い順
## 備考
メモリーの個数、コメントの個数でソートしたく、ransackerで関連モデルの個数を取得するクエリを作っったが、ActiveRecord::StatementInvalid in Musics#indexのエラーが解消できないため、一旦後回しにした。

close #35 
