### PR TITLE
Feature/#131 memory turbo

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -1,12 +1,10 @@
 class MemoriesController < ApplicationController
   def create
-    memory = Memory.new(memory_params)
-    if memory.save
-      flash[:success] = "メモリーを追加しました"
-      redirect_to music_path(memory.music), status: :see_other
+    @memory = Memory.new(memory_params)
+    if @memory.save
+      flash.now[:success] = "メモリーを追加しました"
     else
       flash.now[:erorr] = "メモリーの追加に失敗しました"
-      redirect_to music_path(memory.music), status: :see_other
     end
   end
 
@@ -26,10 +24,9 @@ class MemoriesController < ApplicationController
   end
 
   def destroy
-    memory = Memory.find(params[:id])
-    memory.destroy!
-    flash[:success] = "メモリーを削除しました"
-    redirect_to music_path(memory.music)
+    @memory = Memory.find(params[:id])
+    @memory.destroy!
+    flash.now[:success] = "メモリーを削除しました"
   end
 
   private

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap btn btn-outline"><%= t('views.pagination.truncate').html_safe %></span>
+<span class="page gap btn btn-sm btn-outline">...</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,9 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
-    <%= render 'shared/flash_messages'%>
+    <div id="flash_messages">
+      <%= render 'shared/flash_messages'%>
+    </div>
     <div class="container mx-auto px-5 py-7">
       <%= yield %>
     </div>

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -1,12 +1,14 @@
-<%= form_with model: memory, url: [music, memory], data: { turbo_method: :post } do |form| %>
-  <%#= render 'shared/error_messages', object: form.object %><!-- エラーが出るためコメントアウト　-->
-  <p>タグは3つまで選べます。</p>
-  <% Tag.all.each do |tag| %>
-    <div class="btn btn-sm btn-outline btn-primary">
-      <%= form.check_box :tag_ids, { multiple: true }, tag.id, nil %>
-      <%= tag.name %>
-    </div>
+<div id="memory-form">
+  <%= form_with model: memory, url: [music, memory], data: { turbo_method: :post } do |form| %>
+    <%= render 'shared/error_messages', object: form.object %><!-- エラーが出るためコメントアウト　-->
+    <p>タグは3つまで選べます。</p>
+    <% Tag.all.each do |tag| %>
+      <div class="btn btn-sm btn-outline btn-primary">
+        <%= form.check_box :tag_ids, { multiple: true }, tag.id, nil %>
+        <%= tag.name %>
+      </div>
+    <% end %>
+    <%= form.text_area :body, class: "w-full h-auto my-2 text-base p-1 rounded-lg" %>
+    <%= form.submit "追加する", class: "btn btn-primary" %>
   <% end %>
-  <%= form.text_area :body, class: "w-full h-auto my-2 text-base p-1 rounded-lg" %>
-  <%= form.submit "追加する", class: "btn btn-primary" %>
-<% end %>
+</div>

--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -1,16 +1,18 @@
-<div class="bg-base-100 my-2">
-  <div class="bg-base-300 border-bg-100 p-3 rounded-lg">
-    <% memory.tags.each do |tag| %>
-      <div class="badge badge-primary"><%= tag.name %></div>
-    <% end %>
-
-    <%=  raw Rinku.auto_link(simple_format(memory.body), :urls, 'target="_blank" rel="noopener noreferrer"') %>
-    <div class="object-right-top">
-      <% if logged_in? && current_user.own?(memory.music) %>
-        <%= link_to "削除", memory_path(memory), data: { turbo_method: :delete, turbo_confirm: "本当にこのメモリーを削除しますか？" }, class: "btn btn-sm btn-error float-right" %>
-        <%= link_to "編集", edit_memory_path(memory), class: "btn btn-sm btn-secondary mx-2 float-right" %>
+<div id="memory-<%= memory.id %>">
+  <div class="bg-base-100 my-2">
+    <div class="bg-base-300 border-bg-100 p-3 rounded-lg">
+      <% memory.tags.each do |tag| %>
+        <div class="badge badge-primary"><%= tag.name %></div>
       <% end %>
+
+      <%=  raw Rinku.auto_link(simple_format(memory.body), :urls, 'target="_blank" rel="noopener noreferrer"') %>
+      <div class="object-right-top">
+        <% if logged_in? && current_user.own?(memory.music) %>
+          <%= link_to "削除", memory_path(memory), data: { turbo_method: :delete, turbo_confirm: "本当にこのメモリーを削除しますか？" }, class: "btn btn-sm btn-error float-right" %>
+          <%= link_to "編集", edit_memory_path(memory), class: "btn btn-sm btn-secondary mx-2 float-right" %>
+        <% end %>
+      </div>
+      <p class="text-right"><%= l memory.created_at, format: :long %></p>
     </div>
-    <p class="text-right"><%= l memory.created_at, format: :long %></p>
   </div>
 </div>

--- a/app/views/memories/create.turbo_stream.erb
+++ b/app/views/memories/create.turbo_stream.erb
@@ -1,0 +1,13 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_messages" %>
+<% if @memory.errors.present? %>
+  <%= turbo_stream.replace "memory-form" do %>
+    <%= render 'memories/form', memory: @memory, music: @memory.music %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.prepend "memories-list" do %>
+    <%= render 'memories/memory', memory: @memory %>
+  <% end %>
+  <%= turbo_stream.replace "memory-form" do %>
+    <%= render 'memories/form', memory: Memory.new, music: @memory.music %>
+  <% end %>
+<% end %>

--- a/app/views/memories/destroy.turbo_stream.erb
+++ b/app/views/memories/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_messages" %>
+<%= turbo_stream.remove "memory-#{@memory.id}" do %>
+<% end %>

--- a/app/views/musics/show.html.erb
+++ b/app/views/musics/show.html.erb
@@ -45,7 +45,9 @@
             </div>
           </details>
         <% end %>
-        <%= render @memories %>
+        <div id="memories-list">
+          <%= render @memories %>
+        </div>
       </div>
 
 

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,22 +1,22 @@
 <% flash.each do |message_type, message| %>
   <% case message_type %>
   <% when "info"%>
-    <div role="alert" class="alert alert-info">
+    <div role="alert" class="alert alert-info flex">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
       <span><%= message %></span>
     </div>
   <% when "success" %>
-    <div role="alert" class="alert alert-success">
+    <div role="alert" class="alert alert-success flex">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
       <span><%= message %></span>
     </div>
   <% when "warnig" %>
-    <div role="alert" class="alert alert-warning">
+    <div role="alert" class="alert alert-warning flex">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
       <span><%= message %></span>
     </div>
   <% when "error" %>
-    <div role="alert" class="alert alert-error">
+    <div role="alert" class="alert alert-error flex">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
       <span><%= message %></span>
     </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,3 +13,4 @@ ja:
         created_at: 作成日時
       memory:
         created_at: 作成日時
+        body: メモリー


### PR DESCRIPTION
## 概要
メモリー追加・削除機能をturbo_streamを用いて非同期化した。
フラッシュメッセージも同時に更新するようにした。
## 内容
- コントローラーをturbo用に変更
- ビューのturboターゲットにidを振る
- create.turbo_stream.erbの作成
- destroy.turbo_stream.erbの作成
- レイアウトと日本語訳の修正
## 備考
メモリーの追加に画面遷移を伴わないため、MUのレベルが更新されない。
レベル更新のコールバックは非同期でも行われていることが確認でき、リロードすれば更新される。
差し当たっては問題ないので一旦後回しにする。

close #131 