### PR TITLE
Feature/#121 comment turbo

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,20 +1,17 @@
 class CommentsController < ApplicationController
   def create
-    comment = current_user.comments.build(comment_params)
-    if comment.save
-      flash[:success] = "コメントを追加しました"
-      redirect_to music_path(comment.music)
+    @comment = current_user.comments.build(comment_params)
+    if @comment.save
+      flash.now[:success] = "コメントを追加しました"
     else
-      flash[:error] = "コメントを追加できませんでした"
-      redirect_to music_path(comment.music)
+      flash.now[:error] = "コメントを追加できませんでした"
     end
   end
 
   def destroy
-    comment = current_user.comments.find(params[:id])
-    comment.destroy!
-    flash[:success] = "コメントを削除しました"
-    redirect_to music_path(comment.music), status: :see_other
+    @comment = current_user.comments.find(params[:id])
+    @comment.destroy!
+    flash.now[:success] = "コメントを削除しました"
   end
 
   private

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -4,7 +4,7 @@ class MemoriesController < ApplicationController
     if @memory.save
       flash.now[:success] = "メモリーを追加しました"
     else
-      flash.now[:erorr] = "メモリーの追加に失敗しました"
+      flash.now[:error] = "メモリーを追加できませんでした"
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :user
-  belongs_to :music
+  belongs_to :music, touch: true
   validates :body, presence: true, length: { maximum: 65_535 }
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,14 +1,19 @@
-<div class="bg-base-100 my-2">
-  <div class="bg-base-300 border-bg-100 p-3 rounded-lg">
-      <div class="btn btn-link btn-sm">
-      <%= link_to comment.user.name, "#"%>
+<div id="comment-<%= comment.id %>">
+  <div class="bg-base-100 my-2">
+    <div class="bg-base-300 border-bg-100 p-3 rounded-lg">
+      <%= link_to user_path(comment.user) do %>
+      <div class="flex">
+        <%= image_tag "kkrn_icon_user_1.png", size: "40x40"%>
+        <p class="p-2 link">  <%= comment.user.name %> </p>
       </div>
-    <%= simple_format(comment.body) %>
-    <div class="object-right-top">
-      <% if logged_in? && current_user.own?(comment) %>
-        <%= link_to "削除", comment_path(comment), data: { turbo_method: :delete, turbo_confirm: "本当にこのコメントを削除しますか？" }, class: "btn btn-sm btn-error float-right" %>
       <% end %>
+      <%=  raw Rinku.auto_link(simple_format(comment.body), :urls, 'target="_blank" rel="noopener noreferrer"') %>
+      <div class="object-right-top">
+        <% if logged_in? && current_user.own?(comment) %>
+          <%= link_to "削除", comment_path(comment), data: { turbo_method: :delete, turbo_confirm: "本当にこのコメントを削除しますか？" }, class: "btn btn-sm btn-error float-right" %>
+        <% end %>
+      </div>
+      <p class="text-right"><%= l comment.created_at, format: :long %></p>
     </div>
-    <p class="text-right"><%= l comment.created_at, format: :long %></p>
   </div>
 </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,5 +1,7 @@
-<%= form_with model: comment, url: [music, comment], data: { turbo_method: :post } do |form| %>
-  <%= render 'shared/error_messages', object: form.object %><!-- エラーが出るためコメントアウト　-->
-  <%= form.text_area :body, class: "w-full h-auto my-2 text-base p-1 rounded-lg" %>
-  <%= form.submit "追加する", class: "btn btn-primary" %>
-<% end %>
+<div id="comment-form">
+  <%= form_with model: comment, url: [music, comment], data: { turbo_method: :post } do |form| %>
+    <%= render 'shared/error_messages', object: form.object %>
+    <%= form.text_area :body, class: "w-full h-auto my-2 text-base p-1 rounded-lg" %>
+    <%= form.submit "追加する", class: "btn btn-primary" %>
+  <% end %>
+</div>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,14 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_messages" %>
+
+<% if @comment.errors.present? %>
+  <%= turbo_stream.replace "comment-form" do %>
+    <%= render 'comments/form', comment: @comment, music: @comment.music %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.prepend "comments-list" do %>
+    <%= render 'comments/comment', comment: @comment %>
+  <% end %>
+  <%= turbo_stream.replace "comment-form" do %>
+    <%= render 'comments/form', comment: Comment.new, music: @comment.music %>
+  <% end %>
+<% end %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_messages" %>
+<%= turbo_stream.remove "comment-#{@comment.id}" do %>
+<% end %>

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -1,6 +1,6 @@
 <div id="memory-form">
   <%= form_with model: memory, url: [music, memory], data: { turbo_method: :post } do |form| %>
-    <%= render 'shared/error_messages', object: form.object %><!-- エラーが出るためコメントアウト　-->
+    <%= render 'shared/error_messages', object: form.object %>
     <p>タグは3つまで選べます。</p>
     <% Tag.all.each do |tag| %>
       <div class="btn btn-sm btn-outline btn-primary">

--- a/app/views/musics/_music.html.erb
+++ b/app/views/musics/_music.html.erb
@@ -15,9 +15,9 @@
       </div>
         <%= link_to user_path(music.user) do %>
         <div class="flex">
-            <%= image_tag "kkrn_icon_user_1.png", size: "40x40"%>
+          <%= image_tag "kkrn_icon_user_1.png", size: "40x40"%>
           <p class="p-2 link">  <%= music.user.name %> </p>
-            </div>
+        </div>
         <% end %>
 
       <div class="justify-end">

--- a/app/views/musics/show.html.erb
+++ b/app/views/musics/show.html.erb
@@ -64,7 +64,9 @@
         <% else %>
           <div class="btn btn-sm btn-warning">コメントにはログインが必要です！</div>
         <% end %>
-        <%= render @comments %>
+        <div id="comments-list">
+          <%= render @comments %>
+        </div>
       </div>
     </div>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -14,3 +14,5 @@ ja:
       memory:
         created_at: 作成日時
         body: メモリー
+      comment:
+        body: コメント


### PR DESCRIPTION
## 概要
コメント追加・削除機能のturbo_stream化
## 内容
- コントローラーをturbo用に編集
- ビューのターゲットにidを追加
- create.turbo_stream.erbを追加
- destroy.turbo_stream.erbを追加
- メモリー追加失敗時のフラッシュメッセージのタイポを修正
- コメントの日本語訳を追加
- コメント者のアイコンと名前のリンクを表示
- コメント更新時にMUが更新されるようにtouch: trueを追記
## 備考
コメント編集機能は未実装。インライン編集できるようにしたい。

close #121