### PR TITLE
fix: メモリーが存在するMUを削除した時のバグの修正

### DIFF
--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -19,6 +19,7 @@ class Memory < ApplicationRecord
   private
 
   def update_music_exp
+    return if music.frozen? #music削除に伴うmemory削除でコールバックした際にエラーにならないため追記
     # musicに紐づくすべてのmemoryのbodyの文字数を合計
     total_exp = self.music.memories.sum { |memory| memory.body.length }
     # 合計値をmusicのexpとして保存


### PR DESCRIPTION
## 概要
メモリーが追加してあるMUを削除しようとすると以下エラーが出る。
FrozenError in MusicsController#destroy
can't modify frozen attributes
## 原因
メモリー更新時にmusicの経験値・レベルを更新するコールバックがあるが、music削除時にdependant: :destroyでメモリーが削除され場合にも呼び出される。musicは frozen attributesとなっているため、エラーとなる。
## 解決方法
コールバックupdate_music_expにreturn if music.frozen?をつけた。

close #139 