### PR TITLE
Feature/#157 remember me

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,7 +4,7 @@ class UserSessionsController < ApplicationController
   def new; end
 
   def create
-    @user = login(params[:email], params[:password])
+    @user = login(params[:email], params[:password], params[:remember_me])
 
     if @user
       flash[:success] = 'ログインしました'
@@ -16,6 +16,8 @@ class UserSessionsController < ApplicationController
   end
 
   def destroy
+    remember_me!
+    forget_me!
     logout
     flash[:success] = 'ログアウトしました'
     redirect_to root_url, status: :see_other

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,7 +40,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, :profile, :avatar)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :profile, :avatar, :remember_me)
   end
 
   def set_user

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -15,6 +15,10 @@
         <%= f.password_field :password, class: 'w-full bg-card-body text-theme rounded-lg py-2 px-3'  %>
     </div>
     <div class="flex justify-center flex-col">
+      <label class="cursor-pointer label">
+        <span class="label-text">次回から自動ログイン</span>
+        <%= check_box_tag :remember_me, params[:remember_me], true, class: "toggle toggle-primary" %>
+      </label>
       <%= f.submit 'ログイン', class: "btn btn-secondary mb-2" %>
       <%= link_to 'パスワードをお忘れの方はこちら', new_password_reset_path, class: "link link-primary" %>
       <%= link_to "ユーザー登録", new_user_path, class: "btn btn-accent mt-4" %>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -317,8 +317,8 @@ Rails.application.config.sorcery.configure do |config|
 
     # How long in seconds the session length will be
     # Default: `60 * 60 * 24 * 7`
-    #
-     user.remember_me_for = 180
+    # 4weeks `60 * 60 * 24 * 7 * 4`
+     user.remember_me_for = 2419200
 
     # When true, sorcery will persist a single remember me token for all
     # logins/logouts (to support remembering on multiple browsers simultaneously).

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password]
+Rails.application.config.sorcery.submodules = [:reset_password, :remember_me]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -318,7 +318,7 @@ Rails.application.config.sorcery.configure do |config|
     # How long in seconds the session length will be
     # Default: `60 * 60 * 24 * 7`
     #
-    # user.remember_me_for =
+     user.remember_me_for = 180
 
     # When true, sorcery will persist a single remember me token for all
     # logins/logouts (to support remembering on multiple browsers simultaneously).

--- a/db/migrate/20240416080701_sorcery_remember_me.rb
+++ b/db/migrate/20240416080701_sorcery_remember_me.rb
@@ -1,0 +1,8 @@
+class SorceryRememberMe < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :remember_me_token, :string, default: nil
+    add_column :users, :remember_me_token_expires_at, :datetime, default: nil
+
+    add_index :users, :remember_me_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_07_094500) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_16_080701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,7 +89,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_07_094500) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.string "avatar"
+    t.string "remember_me_token"
+    t.datetime "remember_me_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 


### PR DESCRIPTION
## 概要
[公式wiki](https://github.com/Sorcery/sorcery/wiki/Remember-Me)に従ってリメンバミー（ログイン記憶）機能を実装
## 内容
 - rails g sorcery:install remember_me --only-submodules　実行し、db:migrate
 - user_sessionsコントローラーでparams[:remember_me]を受け取る。
 - ビューにチェックボックスを追加。
 - セッション期間を120秒にして本番環境で動作確認。
 - 確認できたのでセッション期間を4週間に変更。

close #157 