### PR TITLE
Feature/#158 memory privacy

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -14,7 +14,7 @@ class MemoriesController < ApplicationController
 
   def update
     memory = Memory.find(params[:id])
-    if memory.update(params.require(:memory).permit(:body, tag_ids: [])) # 汚いので改善したい。
+    if memory.update(params.require(:memory).permit(:body, :privacy, tag_ids: [])) # 汚いので改善したい。
       flash[:success] = 'メモリーを更新しました'
       redirect_to music_path(memory.music)
     else
@@ -32,6 +32,6 @@ class MemoriesController < ApplicationController
   private
 
   def memory_params
-    params.require(:memory).permit(:body, tag_ids: []).merge(music_id: params[:music_id])
+    params.require(:memory).permit(:body, :privacy, tag_ids: []).merge(music_id: params[:music_id])
   end
 end

--- a/app/helpers/musics_helper.rb
+++ b/app/helpers/musics_helper.rb
@@ -33,7 +33,9 @@ module MusicsHelper
         concat(content_tag(:div, tag.name, class: 'badge badge-primary mr-1'))
       end
 
-      if latest_memory.body.size >= 16
+      if latest_memory.privacy_private? && current_user != music.user
+        concat(content_tag(:p, "非公開のメモリー"))
+      elsif latest_memory.body.size >= 16
         concat(content_tag(:p, "#{latest_memory.body.slice(0..16)}..."))
       else
         concat(content_tag(:p, latest_memory.body))

--- a/app/helpers/musics_helper.rb
+++ b/app/helpers/musics_helper.rb
@@ -23,4 +23,21 @@ module MusicsHelper
       ''
     end
   end
+
+  def display_latest_memory(music)
+    latest_memory = music.memories.order(created_at: :desc).first
+    return unless latest_memory
+
+    content_tag(:div, class: 'justify-end') do
+      latest_memory.tags.each do |tag|
+        concat(content_tag(:div, tag.name, class: 'badge badge-primary mr-1'))
+      end
+
+      if latest_memory.body.size >= 16
+        concat(content_tag(:p, "#{latest_memory.body.slice(0..16)}..."))
+      else
+        concat(content_tag(:p, latest_memory.body))
+      end
+    end
+  end
 end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -6,6 +6,8 @@ class Memory < ApplicationRecord
   validates :body, presence: true, length: { maximum: 65_535 }
   validate :validate_tag_count
 
+  enum privacy: { public: 0, private: 1 }, _prefix: true
+
   after_commit :update_music_exp
 
   private

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -9,7 +9,12 @@
       </div>
     <% end %>
     <%= f.text_area :body, class: "w-full h-24 my-2 text-base p-1 rounded-lg" %>
-    <%= f.select :privacy,{ '公開': :public, '非公開': :private }%>
+    <div class="mb-3">
+      <%= f.radio_button :privacy, :public, class: "radio radio-primary" %>
+      <%= f.label :privacy_public, '公開' %>
+      <%= f.radio_button :privacy, :private, class: "radio radio-primary ml-5" %>
+      <%= f.label :privacy_private, '非公開' %>
+    </div>
     <%= f.submit "追加する", class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -9,6 +9,7 @@
       </div>
     <% end %>
     <%= f.text_area :body, class: "w-full h-24 my-2 text-base p-1 rounded-lg" %>
+    <%= f.select :privacy,{ '公開': :public, '非公開': :private }%>
     <%= f.submit "追加する", class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -5,7 +5,10 @@
         <div class="badge badge-primary"><%= tag.name %></div>
       <% end %>
 
-      <% if current_user != memory.music.user && memory.privacy_private? %>
+      <% if current_user == memory.music.user && memory.privacy_private? %>
+        <p class="text-error">※公開されていません</p>
+        <%= raw Rinku.auto_link(simple_format(memory.body), :urls, 'target="_blank" rel="noopener noreferrer"') %>
+      <% elsif memory.privacy_private? %>
         <p>非公開のメモリー</p>
       <% else %>
         <%= raw Rinku.auto_link(simple_format(memory.body), :urls, 'target="_blank" rel="noopener noreferrer"') %>

--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -5,7 +5,12 @@
         <div class="badge badge-primary"><%= tag.name %></div>
       <% end %>
 
-      <%=  raw Rinku.auto_link(simple_format(memory.body), :urls, 'target="_blank" rel="noopener noreferrer"') %>
+      <% if current_user != memory.music.user && memory.privacy_private? %>
+        <p>非公開のメモリー</p>
+      <% else %>
+        <%= raw Rinku.auto_link(simple_format(memory.body), :urls, 'target="_blank" rel="noopener noreferrer"') %>
+      <% end %>
+
       <div class="object-right-top">
         <% if logged_in? && current_user.own?(memory.music) %>
           <%= link_to "削除", memory_path(memory), data: { turbo_method: :delete, turbo_confirm: "本当にこのメモリーを削除しますか？" }, class: "btn btn-sm btn-error float-right" %>

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -10,6 +10,12 @@
       </div>
     <% end %>
     <%= f.text_area :body, class: "w-full h-auto my-2 text-base p-1 rounded-lg"%>
+    <div class="mb-3">
+      <%= f.radio_button :privacy, :public, class: "radio radio-primary" %>
+      <%= f.label :privacy_public, '公開' %>
+      <%= f.radio_button :privacy, :private, class: "radio radio-primary ml-5" %>
+      <%= f.label :privacy_private, '非公開' %>
+    </div>
     <%= f.submit "編集完了", class: "btn btn-primary" %>
 <% end %>
 </div>

--- a/app/views/musics/_music.html.erb
+++ b/app/views/musics/_music.html.erb
@@ -28,20 +28,7 @@
         <% end %>
 
       <div class="justify-end">
-        <% latest_memory = music.memories.order(created_at: :desc).first %>
-        <% if latest_memory %>
-          <% latest_memory.tags.each do |tag| %>
-            <div class="badge badge-primary">
-              <%= tag.name %>
-            </div>
-          <% end %>
-
-          <% if latest_memory.body.size >= 16 %>
-            <p><%= latest_memory.body.slice(0..16) %>...</p>
-          <% else %>
-            <p><%= latest_memory.body %></p>
-          <% end %>
-        <% end %>
+        <%= display_latest_memory(music) %>
       </div>
     </div>
   </div>

--- a/db/migrate/20240417055309_add_privacy_to_memory.rb
+++ b/db/migrate/20240417055309_add_privacy_to_memory.rb
@@ -1,0 +1,5 @@
+class AddPrivacyToMemory < ActiveRecord::Migration[7.1]
+  def change
+    add_column :memories, :privacy, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_16_080701) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_17_055309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_16_080701) do
     t.text "body", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "privacy", default: 0, null: false
     t.index ["music_id"], name: "index_memories_on_music_id"
   end
 


### PR DESCRIPTION
## 概要
メモリーの公開/非公開設定機能を実装。
## 内容
 - メモリーテーブルにpraivacyカラムを追加する。
 - enum設定する。
 - コントローラーで:privacyを許可する。
 - フォームに公開設定を選ぶボタンを追加。
-  MU詳細画面、一覧画面で非公開かつログインユーザーでない場合は「非公開のメモリー」と表示される。
- ログインユーザーには、非公開のメモリーに「※公開されていません。」という文言がメモリーの前に表示される。
## 備考
MU一覧画面で最新のメモリーを表示するロジックはヘルパーに移動した。

close #158 