### PR TITLE
Feature/#161 sort by count

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'mini_magick'
 
 gem 'fog-aws'
 
+gem 'counter_culture'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,9 @@ GEM
     config (5.4.0)
       deep_merge (~> 1.2, >= 1.2.1)
     connection_pool (2.4.1)
+    counter_culture (3.5.3)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
@@ -416,6 +419,7 @@ DEPENDENCIES
   capybara
   carrierwave
   config
+  counter_culture
   cssbundling-rails
   debug
   dotenv-rails

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :music, touch: true
+  counter_culture :music
   validates :body, presence: true, length: { maximum: 65_535 }
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,5 +1,6 @@
 class Favorite < ApplicationRecord
   belongs_to :user
   belongs_to :music
+  counter_culture :music
   validates :user_id, presence: true, uniqueness: { scope: :music_id }
 end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -2,6 +2,7 @@ class Memory < ApplicationRecord
   belongs_to :music, touch: true
   has_many :memory_tags, dependent: :destroy
   has_many :tags, through: :memory_tags
+  counter_culture :music
 
   validates :body, presence: true, length: { maximum: 65_535 }
   validate :validate_tag_count

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -9,20 +9,6 @@ class Music < ApplicationRecord
 
   after_update :update_level
 
-  ransacker :memories_count do
-    query = <<-SQL
-    (SELECT
-       COUNT(memories.music_id)
-     FROM
-       memories
-     WHERE
-       memories.music_id = music.id
-     GROUP BY
-       memories.music_id)
-    SQL
-    Arel.sql(query)
-  end
-
   private
 
   def update_level
@@ -35,10 +21,10 @@ class Music < ApplicationRecord
   end
 
   def self.ransackable_associations(_auth_object = nil)
-    %w[memories comments tags users]
+    %w[memories comments tags users favorites]
   end
 
   def self.ransortable_attributes(_auth_object = nil)
-    %w[level updated_at memories_count]
+    %w[level updated_at memories_count favorites_count]
   end
 end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -25,6 +25,6 @@ class Music < ApplicationRecord
   end
 
   def self.ransortable_attributes(_auth_object = nil)
-    %w[level updated_at memories_count favorites_count]
+    %w[level updated_at memories_count favorites_count comments_count]
   end
 end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -25,6 +25,6 @@ class Music < ApplicationRecord
   end
 
   def self.ransortable_attributes(_auth_object = nil)
-    %w[level updated_at memories_count favorites_count comments_count]
+    %w[level updated_at memories_count favorites_count comments_count memories_count]
   end
 end

--- a/app/views/musics/_music.html.erb
+++ b/app/views/musics/_music.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= action_name == 'index' ? 'w-[20rem]' : 'w-full' %> p-3">
+<div class="<%= action_name == 'musics/show' ? 'w-full' : 'w-[20rem]' %> p-3">
   <div class="bg-base-100">
     <iframe src="https://open.spotify.com/embed/track/<%= music.spotify_track_id %>" width="100%" height="80" frameborder="0" style="border-radius:12px" allowtransparency="true" allow="encrypted-media" loading="lazy"></iframe>
     <div class="p-2 bg-base-300 rounded-lg">

--- a/app/views/musics/_music.html.erb
+++ b/app/views/musics/_music.html.erb
@@ -1,4 +1,4 @@
-<div class="flex p-3">
+<div class="<%= action_name == 'index' ? 'w-[20rem]' : 'w-full' %> p-3">
   <div class="bg-base-100">
     <iframe src="https://open.spotify.com/embed/track/<%= music.spotify_track_id %>" width="100%" height="80" frameborder="0" style="border-radius:12px" allowtransparency="true" allow="encrypted-media" loading="lazy"></iframe>
     <div class="p-2 bg-base-300 rounded-lg">

--- a/app/views/musics/index.html.erb
+++ b/app/views/musics/index.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div>
     <%= search_form_for @q, html: { data: { turbo_frame: "musics-list" } } do |f| %>
-      <%= f.select(:sorts, {'レベル高い順': 'level desc', '更新新しい順': 'updated_at desc', '更新古い順': 'updated_at asc'}, { include_blank: '選択してください' }, class: "w-300 py-1 px-3 mr-1 rounded-lg") %>
+      <%= f.select(:sorts, {'レベル高い順': 'level desc', 'いいね多い順': 'favorites_count desc', '更新新しい順': 'updated_at desc', '更新古い順': 'updated_at asc'}, { include_blank: '選択してください' }, class: "w-300 py-1 px-3 mr-1 rounded-lg") %>
       <%= f.submit "並び替え", class: "btn btn-sm btn-primary my-2" %>
     <% end %>
   </div>

--- a/app/views/musics/index.html.erb
+++ b/app/views/musics/index.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div>
     <%= search_form_for @q, html: { data: { turbo_frame: "musics-list" } } do |f| %>
-      <%= f.select(:sorts, {'レベル高い順': 'level desc', 'いいね多い順': 'favorites_count desc', '更新新しい順': 'updated_at desc', '更新古い順': 'updated_at asc'}, { include_blank: '選択してください' }, class: "w-300 py-1 px-3 mr-1 rounded-lg") %>
+      <%= f.select(:sorts, {'レベル高い順': 'level desc', 'いいね多い順': 'favorites_count desc', 'コメント数多い順': 'comments_count desc', '更新新しい順': 'updated_at desc', '更新古い順': 'updated_at asc'}, { include_blank: '選択してください' }, class: "w-300 py-1 px-3 mr-1 rounded-lg") %>
       <%= f.submit "並び替え", class: "btn btn-sm btn-primary my-2" %>
     <% end %>
   </div>

--- a/app/views/musics/index.html.erb
+++ b/app/views/musics/index.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div>
     <%= search_form_for @q, html: { data: { turbo_frame: "musics-list" } } do |f| %>
-      <%= f.select(:sorts, {'レベル高い順': 'level desc', 'いいね多い順': 'favorites_count desc', 'コメント数多い順': 'comments_count desc', '更新新しい順': 'updated_at desc', '更新古い順': 'updated_at asc'}, { include_blank: '選択してください' }, class: "w-300 py-1 px-3 mr-1 rounded-lg") %>
+      <%= f.select(:sorts, {'レベル上位': 'level desc', 'いいね数上位': 'favorites_count desc', 'コメント数上位': 'comments_count desc', 'メモリー数上位': 'memories_count desc', '更新順': 'updated_at desc'}, { include_blank: '選択してください' }, class: "w-300 py-1 px-3 mr-1 rounded-lg") %>
       <%= f.submit "並び替え", class: "btn btn-sm btn-primary my-2" %>
     <% end %>
   </div>

--- a/db/migrate/20240419084815_add_favorites_count_to_musics.rb
+++ b/db/migrate/20240419084815_add_favorites_count_to_musics.rb
@@ -1,0 +1,9 @@
+class AddFavoritesCountToMusics < ActiveRecord::Migration[7.1]
+  def self.up
+    add_column :musics, :favorites_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :musics, :favorites_count
+  end
+end

--- a/db/migrate/20240419093237_add_comments_count_to_musics.rb
+++ b/db/migrate/20240419093237_add_comments_count_to_musics.rb
@@ -1,0 +1,9 @@
+class AddCommentsCountToMusics < ActiveRecord::Migration[7.1]
+  def self.up
+    add_column :musics, :comments_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :musics, :comments_count
+  end
+end

--- a/db/migrate/20240419094234_add_memories_count_to_musics.rb
+++ b/db/migrate/20240419094234_add_memories_count_to_musics.rb
@@ -1,0 +1,9 @@
+class AddMemoriesCountToMusics < ActiveRecord::Migration[7.1]
+  def self.up
+    add_column :musics, :memories_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :musics, :memories_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_19_093237) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_19_094234) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_19_093237) do
     t.integer "level", default: 1
     t.integer "favorites_count", default: 0, null: false
     t.integer "comments_count", default: 0, null: false
+    t.integer "memories_count", default: 0, null: false
     t.index ["user_id"], name: "index_musics_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_17_055309) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_19_084815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,6 +68,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_17_055309) do
     t.datetime "updated_at", null: false
     t.integer "experience_point", default: 0
     t.integer "level", default: 1
+    t.integer "favorites_count", default: 0, null: false
     t.index ["user_id"], name: "index_musics_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_19_084815) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_19_093237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_19_084815) do
     t.integer "experience_point", default: 0
     t.integer "level", default: 1
     t.integer "favorites_count", default: 0, null: false
+    t.integer "comments_count", default: 0, null: false
     t.index ["user_id"], name: "index_musics_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
いいね数、メモリー数、コメント数でソートできる機能を追加。
## 内容
 - gem counter_culture　をインストール。
 - rails generate counter_culture コマンドでMusicテーブルにfavorites_count、comments_count、memories_countカラムを追加。
 - アソシエーションに、counter_cultureを追加。
 - 並び替えフォームに追加。
 - ransortable_attributesに各カラムを追加。
 - renderのコンソールでFavorite.counter_culture_fix_countsを実行し現在のカウントを反映させる（他テーブルも同様）。
 - 曲名が長すぎるときに一覧画面のレイアウトが崩れるのを修正。
## 備考
gem counter_cultureを使い、カウント用のカラムを用意する。
[関連レコード数の集計（カウンターキャッシュ）](https://qiita.com/kanekomasanori@github/items/8155dff193e961828d02)

close #161 , #168