### PR TITLE
Fix/#170 RAM_memory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem 'fog-aws'
 
 gem 'counter_culture'
 
+gem 'puma_worker_killer'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -271,6 +273,9 @@ GEM
     public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
+    puma_worker_killer (0.3.1)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7)
     racc (1.7.3)
     rack (3.0.9.1)
     rack-protection (4.0.0)
@@ -433,6 +438,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)
+  puma_worker_killer
   rails (~> 7.1.3, >= 7.1.3.2)
   rails-i18n
   ransack

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -48,7 +48,7 @@
 <!-- いいねしたMU-->
       <input type="radio" name="my_tabs_2" role="tab" class="tab" aria-label="いいねしたMU" />
       <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
-        <%= turbo_frame_tag "musics-list", autoscroll: true, data: { autoscroll_block: "start" } do %>
+        <%= turbo_frame_tag "favorite-musics-list", autoscroll: true, data: { autoscroll_block: "start" } do %>
           <div class="flex flex-wrap justify-center">
             <%= render @favorite_musics %>
           </div>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,7 +36,7 @@ plugin :tmp_restart
 
 preload_app!
 
-workers ENV.fetch('WEB_CONCURRENCY') { 3 }
+workers ENV.fetch('WEB_CONCURRENCY') { 4 }
 
 before_fork do
   PumaWorkerKiller.config do |config|

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,4 +36,4 @@ plugin :tmp_restart
 
 preload_app!
 
-workers ENV.fetch('WEB_CONCURRENCY') { 4 }
+workers ENV.fetch('WEB_CONCURRENCY') { 3 }

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -37,3 +37,14 @@ plugin :tmp_restart
 preload_app!
 
 workers ENV.fetch('WEB_CONCURRENCY') { 3 }
+
+before_fork do
+  PumaWorkerKiller.config do |config|
+    config.ram           = 512
+    config.frequency     = 5
+    config.percent_usage = 0.65
+    config.rolling_restart_frequency = 12 * 3600
+    config.reaper_status_logs = true
+  end
+  PumaWorkerKiller.start
+end


### PR DESCRIPTION
## 概要
RAMメモリが512MBギリギリになっており、落ちてしまうので改善のためにgem 'puma_worker_killer'を導入した。
![image](https://github.com/ken55ty/stay_with_mu/assets/142506480/60c7a8a8-92b0-421d-b740-fbe02a2a955c)
## 内容
gem 'puma_worker_killer'を導入。

**設定内容**
 - 規定のRAM(512MB)の65%を使用するとワーカープロセスを再起動
 - 5秒ごとに使用量を監視
 - 使用量に関わらず12時間に1回、定期的にワーカープロセスを再起動

## 結果
一度worker数を4→3に減らしたが90%前後だった。puma_worker_killer導入後は50%前後で抑えられている。
![image](https://github.com/ken55ty/stay_with_mu/assets/142506480/10c0c8e7-2bcb-4e07-8c0a-7812982d0ab8)


## いいねしたMUのページネーションがつくったMUと混ざるバグを修正
つくったMUといいねしたMUのturbo_frame_tagのidが同一で合ったため、いいね一覧のページネーションでつくったMUのページが表示されていた。

close #170 , close #171