### PR TITLE
Feature/#173 notification

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,20 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
+  before_action :set_norification_object
+  include NotificationsHelper
 
   private
 
   def not_authenticated
     flash[:warnig] = 'ログインが必要です'
     redirect_to login_path
+  end
+
+  def set_norification_object
+    if current_user
+      @notifications = current_user.received_notifications.unread.limit(10)
+    else
+      @notifications = []
+    end
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,6 +6,7 @@ class CommentsController < ApplicationController
   def create
     @comment = current_user.comments.build(comment_params)
     if @comment.save
+      @comment.create_notification_comment!(current_user, @comment.id)
       flash.now[:success] = 'コメントを追加しました'
     else
       flash.now[:error] = 'コメントを追加できませんでした'

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,39 @@
+class NotificationsController < ApplicationController
+  def update
+    @notification = current_user.received_notifications.find(params[:id])
+    @notification.update(unread: false)
+    if @notification
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: [
+              turbo_stream.remove(@notification),
+              turbo_stream.replace('notification_count', partial: 'notifications/notification_count', locals: { notifications: current_user.notifications.unread })
+          ]
+        end
+        format.html
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: [
+              turbo_stream.replace('notifications', '')
+          ]
+        end
+      end
+    end
+  end
+
+  def mark_all_as_read
+    @notifications = current_user.received_notifications.unread
+    @notifications.destroy_all
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.remove('notifications'),
+          turbo_stream.replace('notification_count', partial: 'notifications/notification_count', locals: { notifications: current_user.notifications.unread })
+        ]
+      end
+      format.html
+    end
+  end
+end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,18 @@
+module NotificationsHelper
+  def generate_notification_message(notification)
+    return unless notification
+
+    case notification.notifiable_type
+    when 'Comment'
+      "#{notification.sender.name}が#{generate_music_link(notification.notifiable.music)}にコメントしました".html_safe
+    when 'Favorite'
+      "#{notification.sender.name}が#{generate_music_link(notification.notifiable.music)}にいいね！しました".html_safe
+    else
+      "新着通知がありました"
+    end
+  end
+
+  def generate_music_link(music)
+    link_to music.title, music_path(music), class: "link link-primary", data: { turbo: false }
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,7 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :music, touch: true
+  has_one :notification, as: :notifiable, dependent: :destroy
   counter_culture :music
   validates :body, presence: true, length: { maximum: 65_535 }
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,4 +4,31 @@ class Comment < ApplicationRecord
   has_one :notification, as: :notifiable, dependent: :destroy
   counter_culture :music
   validates :body, presence: true, length: { maximum: 65_535 }
+
+  def create_notification_comment!(current_user, comment_id)
+    #MUのユーザーに通知を送る
+    save_notification_comment!(current_user, comment_id, music.user_id)
+
+    # 自分以外にコメントしている人をすべて取得し、全員に通知を送る
+    other_commenters_ids = Comment.select(:user_id).where(music_id: music_id).where.not(user_id: current_user.id).distinct.pluck(:user_id)
+
+    # 各コメントユーザーに対して通知を作成
+    other_commenters_ids.each do |commenter_id|
+      save_notification_comment!(current_user, comment_id, commenter_id)
+    end
+  end
+
+  def save_notification_comment!(current_user, comment_id, recipient_id)
+    notification = Notification.new(
+      sender_id: current_user.id,
+      recipient_id: recipient_id,
+      notifiable: self
+    )
+
+    # 自分の投稿に対するコメントの場合は、既読とする
+    notification.unread = false if notification.sender_id == notification.recipient_id
+
+    # 通知を保存（バリデーションが成功する場合のみ）
+    notification.save if notification.valid?
+  end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -4,4 +4,18 @@ class Favorite < ApplicationRecord
   has_one :notification, as: :notifiable, dependent: :destroy
   counter_culture :music
   validates :user_id, presence: true, uniqueness: { scope: :music_id }
+
+  after_create_commit :create_favorite_notification
+
+  private
+
+  def create_favorite_notification
+    return if self.user_id == self.music.user_id
+
+    Notification.create(
+      sender_id: self.user_id,
+      recipient_id: self.music.user_id,
+      notifiable: self
+    )
+  end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,6 +1,7 @@
 class Favorite < ApplicationRecord
   belongs_to :user
   belongs_to :music
+  has_one :notification, as: :notifiable, dependent: :destroy
   counter_culture :music
   validates :user_id, presence: true, uniqueness: { scope: :music_id }
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,8 @@
+class Notification < ApplicationRecord
+  default_scope -> { order(created_at: "desc") }
+  belongs_to :sender, class_name: 'User', foreign_key: 'sender_id'
+  belongs_to :recipient, class_name: 'User', foreign_key: 'recipient_id'
+  belongs_to :notifiable, polymorphic: true
+
+  scope :unread, -> { where(unread: true) }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,9 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :favorite_musics, through: :favorites, source: :music
+  has_many :sent_notifications, class_name: 'Notification', foreign_key: 'sender_id', dependent: :destroy
+  has_many :received_notifications, class_name: 'Notification', foreign_key: 'recipient_id', dependent: :destroy
+  has_many :notifications, as: :notifiable, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 20 }
   validates :email, presence: true, uniqueness: true

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,0 +1,15 @@
+<%= turbo_frame_tag dom_id(notification) do %>
+<li data-notification-id="<%= notification.id %>" class="<%= notification.unread ? 'unread' : '' %> dropdown-item">
+  <div class="flex w-full mt-1">
+    <%= link_to notification_path(notification), method: :patch, data: { turbo_method: :patch }, class: "text-primary" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-check" viewBox="0 0 16 16">
+        <path d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"/>
+      </svg>
+    <% end %>
+    <div>
+      <%= generate_notification_message(notification) %>
+    </div>
+  </div>
+  <p class="text-xs pl-8"><%= time_ago_in_words(notification.created_at) %>前</p>
+</li>
+<% end %>

--- a/app/views/notifications/_notification_count.html.erb
+++ b/app/views/notifications/_notification_count.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag 'notification_count' do %>
+  <% if current_user.received_notifications.unread.present? %>
+    <span class="absolute top-2 right-2 rounded-full badge badge-error badge-sm">
+      <%= current_user.received_notifications.unread.size %>
+    </span>
+  <% end %>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,6 +7,18 @@
   <nav class="mr-2 flex">
     <%= link_to "みんなのMU", musics_path, class: "btn btn-sm btn-primary btn-outline mr-2 sm:btn-md"%>
     <%= link_to "MUをつくる", new_music_path, class: "btn btn-sm btn-secondary btn-outline mr-1 sm:btn-md"%>
+    <div class="dropdown dropdown-end">
+      <div tabindex="0" class="m-1 btn">
+        <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-bell" viewBox="0 0 16 16">
+          <path d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2zM8 1.918l-.797.161A4.002 4.002 0 0 0 4 6c0 .628-.134 2.197-.459 3.742-.16.767-.376 1.566-.663 2.258h10.244c-.287-.692-.502-1.49-.663-2.258C12.134 8.197 12 6.628 12 6a4.002 4.002 0 0 0-3.203-3.92L8 1.917zM14.22 12c.223.447.481.801.78 1H1c.299-.199.557-.553.78-1C2.68 10.2 3 6.88 3 6c0-2.42 1.72-4.44 4.005-4.901a1 1 0 1 1 1.99 0A5.002 5.002 0 0 1 13 6c0 .88.32 4.2 1.22 6z"/>
+        </svg>
+          <%= render 'notifications/notification_count' %>
+      </div>
+
+      <div class="dropdown-content z-[1] p-2 bg-neutral rounded-box w-[22rem]">
+        <%= render 'shared/notifications_dropdown' %>
+      </div>
+    </div>
     <%= link_to user_path(current_user), class:"mr-1" do %>
       <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" width="32" height="32" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
     <% end %>

--- a/app/views/shared/_notifications_dropdown.html.erb
+++ b/app/views/shared/_notifications_dropdown.html.erb
@@ -1,0 +1,16 @@
+<ul class="dropdown-menu dropdown-menu-lg-end">
+  <%= turbo_frame_tag 'notifications' do %>
+    <% if @notifications.present? %>
+      <%= link_to '全てを既読する', mark_all_as_read_notifications_path,
+        class: 'btn btn-outline btn-sm mx-auto',
+        method: :delete,
+        remote: true,
+        data: {turbo_method: :delete } %>
+      <% @notifications.each do |notification| %>
+        <%= render 'notifications/notification', { notification: notification } %>
+      <% end %>
+    <% else %>
+      <div class="ml-3">未読のお知らせはありません。</div>
+    <% end %>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,11 @@ Rails.application.routes.draw do
     resources :memories, only: %i[create edit update destroy], shallow: true
     resources :comments, only: %i[create edit update destroy], shallow: true
   end
+  resources :notifications, only: %i[update] do
+    collection do
+      delete :mark_all_as_read
+    end
+  end
   resources :favorites, only: %i[create destroy]
   resources :password_resets, only: %i[new create edit update]
   get 'login', to: 'user_sessions#new', as: :login

--- a/db/migrate/20240422091731_create_notifications.rb
+++ b/db/migrate/20240422091731_create_notifications.rb
@@ -1,0 +1,12 @@
+class CreateNotifications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notifications do |t|
+      t.references :sender, null: false, foreign_key: { to_table: :users }
+      t.references :recipient, null: false, foreign_key: { to_table: :users }
+      t.references :notifiable, polymorphic: true, null: false
+      t.boolean :unread, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_19_094234) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_22_091731) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_19_094234) do
     t.index ["user_id"], name: "index_musics_on_user_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "sender_id", null: false
+    t.bigint "recipient_id", null: false
+    t.string "notifiable_type", null: false
+    t.bigint "notifiable_id", null: false
+    t.boolean "unread", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
+    t.index ["sender_id"], name: "index_notifications_on_sender_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -108,4 +121,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_19_094234) do
   add_foreign_key "memory_tags", "memories"
   add_foreign_key "memory_tags", "tags"
   add_foreign_key "musics", "users"
+  add_foreign_key "notifications", "users", column: "recipient_id"
+  add_foreign_key "notifications", "users", column: "sender_id"
 end


### PR DESCRIPTION
## 概要
通知機能（アプリ内）の実装。以下のタイミングで通知を送る。
・自分のMUにいいねされた時
・自分のMU・自分がコメントしたことがあるMUにコメントがされた時
## 内容
- Notificationテーブル作成
- Notificationモデル作成、アソシエーション追加
- いいね時にMUユーザーに通知を送るコールバックメソッドを追加
- コメント時にMUユーザーとコメントしているユーザーに通知を送るモデルメソッドを追加し、コメントcreate後呼び出す。
- notificationコントローラー追加
- 通知本文を生成するヘルパーメソッドを追加
- ヘッダーに通知ドロップボタンを追加
- 通知一覧のパーシャルを作成
- 通知パーシャルを作成
- 通知数パーシャルを作成
