### PR TITLE
Fix/#181 link button

### DIFF
--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,6 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="first btn btn-sm btn-outline">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
-</span>
+
+<%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "first btn btn-sm btn-outline" %>
+

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,6 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="last btn btn-sm btn-outline">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
-</span>
+<%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "last btn btn-sm btn-outline" %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,6 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="next btn btn-sm btn-outline">
-  <%= link_to_unless current_page.last?, "＞", url, rel: 'next', remote: remote %>
-</span>
+<%= link_to_unless current_page.last?, "＞", url, rel: 'next', remote: remote, class: "next btn btn-sm btn-outline" %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -7,6 +7,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page<%= ' current' if page.current? %> btn  btn-sm btn-outline">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+<span class="page<%= ' current btn btn-sm btn-outline' if page.current? %> ">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "btn btn-sm btn-outline"} %>
 </span>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,6 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="prev btn  btn-sm btn-outline">
-  <%= link_to_unless current_page.first?, "＜", url, rel: 'prev', remote: remote %>
-</span>
+<%= link_to_unless current_page.first?, "＜", url, rel: 'prev', remote: remote, class: "prev btn btn-sm btn-outline" %>

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -3,10 +3,10 @@
     <%= render 'shared/error_messages', object: f.object %>
     <p>タグは3つまで選べます。</p>
     <% Tag.all.each do |tag| %>
-      <div class="btn btn-sm btn-outline btn-primary">
+      <label class="btn btn-sm btn-outline btn-primary">
         <%= f.check_box :tag_ids, { multiple: true }, tag.id, nil %>
         <%= tag.name %>
-      </div>
+      </label>
     <% end %>
     <%= f.text_area :body, class: "w-full h-24 my-2 bg-base-300 textarea textarea-bordered p-1 rounded-lg" %>
     <div class="mb-3">

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -4,10 +4,10 @@
   <%= form_with model: @memory, local: true do |f| %>
     <%#= render 'shared/error_messages', object: f.object %><!-- エラーが出るためコメントアウト　-->
     <% Tag.all.each do |tag| %>
-      <div class="btn btn-sm btn-outline btn-primary">
+      <label class="btn btn-sm btn-outline btn-primary">
         <%= f.check_box :tag_ids, { multiple: true }, tag.id, nil %>
         <%= tag.name %>
-      </div>
+      </label>
     <% end %>
     <%= f.text_area :body, class: "w-full h-auto my-2 text-base p-1 rounded-lg"%>
     <div class="mb-3">


### PR DESCRIPTION
## 概要
・ページネーションのリンクがボタン全体ではなく、ボタンの中の文字のみ反応する状態だったので、ボタン全体をリンクとして反応するよう修正。
・メモリーのタグを選択する時に、要素全体ではなく、チェックボックスしか反応しない状態だったので、ボタンをラベルとしてボタン全体が反応するように修正。

close #181 