### PR TITLE
Feature/#180 autocomplete

### DIFF
--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -8,20 +8,23 @@ class MusicsController < ApplicationController
   end
 
   def search
-    if params[:search].present?
-      search_results = RSpotify::Track.search(params[:search])
+    if params[:q].present?
+      search_results = RSpotify::Track.search(params[:q])
       @musics = search_results.first(20).map do |track|
-        {
-          id: track.id,
+        Music.new(
+          spotify_track_id: track.id,
           title: track.name,
           artist: track.artists.first.name
-        }
+        )
       end
     else
       @musics = [] # 検索クエリがない場合は空の結果を返す
     end
 
-    render :new
+    respond_to do |format|
+      format.js { render partial: 'musics/autocompletes/new_autocomplete', locals: { musics: @musics } }
+      format.html { render :new }
+    end
   end
 
   def show

--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -1,5 +1,5 @@
 class MusicsController < ApplicationController
-  skip_before_action :require_login, only: %i[index show]
+  skip_before_action :require_login, only: %i[index show index_autocomplete]
 
   def index
     @q = Music.ransack(params[:q])
@@ -54,6 +54,11 @@ class MusicsController < ApplicationController
     music.destroy!
     flash[:success] = 'MUを削除しました'
     redirect_to musics_path, status: :see_other
+  end
+
+  def index_autocomplete
+    @musics = Music.where('title ILIKE ? OR artist ILIKE ?', "%#{params[:q]}%", "%#{params[:q]}%").distinct.limit(10)
+    render partial: 'musics/autocompletes/index_autocomplete', locals: { musics: @musics, query: params[:q] }
   end
 
   private

--- a/app/javascript/controllers/create_autocomplete_controller.js
+++ b/app/javascript/controllers/create_autocomplete_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+import { Autocomplete } from 'stimulus-autocomplete'
+
+// Connects to data-controller="create-autocomplete"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/create_autocomplete_controller.js
+++ b/app/javascript/controllers/create_autocomplete_controller.js
@@ -1,8 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-import { Autocomplete } from 'stimulus-autocomplete'
-
-// Connects to data-controller="create-autocomplete"
-export default class extends Controller {
-  connect() {
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,9 +4,6 @@
 
 import { application } from "./application"
 
-import CreateAutocompleteController from "./create_autocomplete_controller"
-application.register("create-autocomplete", CreateAutocompleteController)
-
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,11 @@
 
 import { application } from "./application"
 
+import CreateAutocompleteController from "./create_autocomplete_controller"
+application.register("create-autocomplete", CreateAutocompleteController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import { Autocomplete } from "stimulus-autocomplete"
+application.register("autocomplete", Autocomplete)

--- a/app/views/musics/_search_form.html.erb
+++ b/app/views/musics/_search_form.html.erb
@@ -1,8 +1,9 @@
 <div class="mx-auto">
-  <div>
-  <%= form_with url: search_musics_path, method: :get, local: true do |f| %>
-    <%= f.text_field :search, class: "input input-bordered input-sm sm:input-md bg-base-300 w-[16rem] sm:w-[32rem]", placeholder: "曲名orアーティストで検索" %>
-    <%= f.submit '検索', name: nil, class: "btn btn-sm btn-primary ml-2" %>
-  <% end %>
+  <div data-controller="autocomplete" data-autocomplete-url-value="/musics/search" role="combobox">
+    <%= form_with url: search_musics_path, method: :get, html: { data:  { turbo_frame: "search_results", turbo_action: :advance }  }  do |f| %>
+      <%= f.text_field :q, data: { autocomplete_target: "input" }, class: "input input-bordered input-sm sm:input-md bg-base-300 w-[16rem] sm:w-[32rem]", placeholder: "曲名orアーティストで検索" %>
+      <ul class="list-group bg-gray-200 rounded-md absolute w-full md:text-sm max-w-max z-50" data-autocomplete-target="results"></ul>
+      <%= f.submit '検索', name: nil, class: "btn btn-sm btn-primary ml-2" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/musics/_search_result.html.erb
+++ b/app/views/musics/_search_result.html.erb
@@ -1,16 +1,19 @@
 <div class="mt-4">
-  <h2 class="text-center font-bold mb-2">検索結果</h2>
-  <div class="flex flex-wrap justify-center">
-    <% musics.each do |music| %>
-      <div class="p-1 my-2 border-radius">
-        <iframe src="https://open.spotify.com/embed/track/<%= music[:id] %>" width="100%" height="80" frameborder="0" style="border-radius:12px" allowtransparency="true" allow="encrypted-media"></iframe>
-        <%= form_with url: musics_path, data: {turbo_method: :post, turbo_confirm: "このMUを作成しますか？"} do |form| %>
-          <%= form.hidden_field :spotify_track_id, value: music[:id] %>
-          <%= form.hidden_field :artist, value: music[:artist] %>
-          <%= form.hidden_field :title, value: music[:title] %>
-          <%= form.submit 'MUをつくる！', class: "btn btn-sm btn-outline btn-primary mt-2" %>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
+  <h2 class="text-center mb-2">検索結果</h2>
+  <%= turbo_frame_tag "search_results" do %>
+    <div class="flex flex-wrap justify-center">
+      <% musics.each do |music| %>
+        <div class="p-1 my-2 border-radius">
+          <iframe src="https://open.spotify.com/embed/track/<%= music.spotify_track_id %>" width="100%" height="80" frameborder="0" style="border-radius:12px" allowtransparency="true" allow="encrypted-media" loading="lazy"></iframe>
+          <%# turbo: falseなので確認メッセージが出せない。要改善。 %>
+          <%= form_with url: musics_path, data: { turbo: false, turbo_method: :post, turbo_confirm: "このMUを作成しますか？"} do |form| %>
+            <%= form.hidden_field :spotify_track_id, value: music.spotify_track_id %>
+            <%= form.hidden_field :artist, value: music.artist %>
+            <%= form.hidden_field :title, value: music.title %>
+            <%= form.submit 'MUをつくる！', class: "btn btn-sm btn-outline btn-primary mt-2" %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/musics/autocompletes/_index_autocomplete.html.erb
+++ b/app/views/musics/autocompletes/_index_autocomplete.html.erb
@@ -1,0 +1,14 @@
+<% displayed_artists = [] %>
+<% musics.each do |music| %>
+  <% next if displayed_artists.include?(music.artist) %>
+  <% displayed_artists << music.artist %>
+  <% if music.title.downcase.include?(query.downcase) %>
+    <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 z-40 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= music.title %>" data-autocomplete-label="<%= music.title %>">
+      <%= music.artist %> / <%= music.title %>
+    </li>
+  <% elsif music.artist.downcase.include?(query.downcase) %>
+    <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 z-40 rounded-md text-sm text-blue-700 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= music.artist %>" data-autocomplete-label="<%= music.artist %>">
+      <%= music.artist %>
+    </li>
+  <% end %>
+<% end %>

--- a/app/views/musics/autocompletes/_new_autocomplete.html.erb
+++ b/app/views/musics/autocompletes/_new_autocomplete.html.erb
@@ -1,0 +1,5 @@
+<% musics.each do |music| %>
+  <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= music.artist%> <%= music.title %>" data-autocomplete-label="<%= music.title %>">
+    <%= music.artist %> / <%= music.title %>
+  </li>
+<% end %>

--- a/app/views/musics/index.html.erb
+++ b/app/views/musics/index.html.erb
@@ -18,14 +18,16 @@
     <%= image_tag "djmya3.png", class: "mt-8 size-20 sm:size-28" %>
 </div>
 
-
 <h1 class="text-center py-4 text-2xl">みんなのMU</h1>
 <div class="flex justify-center mb-6">
   <div class="mr-1">
-    <%= search_form_for @q, html: { data: { turbo_frame: "musics-list" } } do |f| %>
-      <%= f.search_field :title_or_artist_cont, class: "input input-bordered input-sm sm:input-md bg-base-300 w-[12rem] sm:w-[24rem] max-w-xs", placeholder: "曲名orアーティスト" %>
-      <%= f.submit "検索", class: "btn btn-sm btn-primary my-2 ml-2" %>
-    <% end %>
+    <div data-controller="autocomplete" data-autocomplete-url-value="/musics/index_autocomplete" role="combobox">
+      <%= search_form_for @q, html: { data: { turbo_frame: "musics-list", turbo_action: :advance} } do |f| %>
+        <%= f.search_field :title_or_artist_cont, class: "input input-bordered input-sm sm:input-md bg-base-300 w-[12rem] sm:w-[24rem] max-w-xs", placeholder: "曲名orアーティスト", data: { autocomplete_target: "input" }  %>
+        <ul class="list-group bg-gray-200 rounded-md absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+        <%= f.submit "検索", class: "btn btn-sm btn-primary my-2 ml-2" %>
+      <% end %>
+    </div>
   </div>
   <div>
     <%= search_form_for @q, html: { data: { turbo_frame: "musics-list" } } do |f| %>
@@ -34,7 +36,7 @@
     <% end %>
   </div>
 </div>
-<%= turbo_frame_tag "musics-list", autoscroll: true, data: { autoscroll_block: "start" }  do %>
+<%= turbo_frame_tag "musics-list"  do %>
   <div class="flex flex-wrap justify-center mb-4">
     <%= render @musics %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :musics do
     collection do
       get :search
+      get :index_autocomplete
     end
     resources :memories, only: %i[create edit update destroy], shallow: true
     resources :comments, only: %i[create edit update destroy], shallow: true

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "daisyui": "^4.7.3",
     "esbuild": "^0.20.2",
     "postcss": "^8.4.35",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^3.4.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,6 +821,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   name string-width-cjs
   version "4.2.3"


### PR DESCRIPTION
## 概要
[stimulus-autocomplete](https://github.com/afcapel/stimulus-autocomplete)を用いて、MU一覧画面の検索時および、MU作成時のオートコンプリート（入力補完）機能を実装。
MU作成画面のturbo-frame導入も同時に行なった。
## 実現したこと
- 一覧画面
曲名でヒットした場合、アーティスト名 / 曲名の形でサジェストされ、選択すると曲名が検索フィールドに入力される。
![07705251173a9a575be2d722b0713ddc](https://github.com/ken55ty/stay_with_mu/assets/142506480/e9de2c00-2868-4e17-aad2-94e1db46ba43)
アーティスト名がヒットした場合、アーティスト名がサジェストされ、選択するとアーティスト名が検索フィールドに入力される。
![28d52572b5ddca62aaf352c433f6ad81](https://github.com/ken55ty/stay_with_mu/assets/142506480/8bbffea7-ad59-4400-a5f5-af70fa886568)
- MU作成画面
![c7c0290791282a4ee938c3987704d41a](https://github.com/ken55ty/stay_with_mu/assets/142506480/f7103ec7-417b-49ca-9152-2424e04f2725)

## 課題
- 一覧のオートコンプリートではひらがな・カタカナ・漢字・ローマ字の区別を無くせなかった。
- MU作成時の検索結果のテンプレートをturbo_frame_tagで囲い、turbo化したが、「MUをつくる！」ボタンがturboリクエストではないので、turbo: falseにしたため、turbo_confirmが使えなくなり、確認メッセージが出せなくなった。
- MU作成時の検索の1度目はturboにならず、検索フィールドの値を引き継げない。

close #180 

