### PR TITLE
自動ズームを無効に、Xシェアボタンを変更、ページタイトルが反映しないバグを修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,9 +28,4 @@ module ApplicationHelper
       }
     }
   end
-
-  def page_title(title = '')
-    base_title = 'STAY with MU'
-    title.present? ? "#{title} | #{base_title}" : base_title
-  end
 end

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <div class="h-screen">
   <h1 class="text-center py-4 text-2xl">メモリー編集</h1>
   <%= form_with model: @comment, local: true do |f| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= page_title(content_for?(:title) ? yield(:title) : '') %></title>
+
     <%= favicon_link_tag asset_path('MUfavicon.svg') %>
     <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1.0">
     <%= csrf_meta_tags %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title><%= page_title(content_for?(:title) ? yield(:title) : '') %></title>
     <%= favicon_link_tag asset_path('MUfavicon.svg') %>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1.0">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= display_meta_tags(default_meta_tags) %>

--- a/app/views/memories/edit.html.erb
+++ b/app/views/memories/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <div class="h-screen">
   <h1 class="text-center py-4 text-2xl">メモリー編集</h1>
   <%= form_with model: @memory, local: true do |f| %>

--- a/app/views/musics/index.html.erb
+++ b/app/views/musics/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <div class=" flex justify-end">
 <label class="swap mr-3">
   <input type="checkbox" />

--- a/app/views/musics/new.html.erb
+++ b/app/views/musics/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <div>
   <h1 class="text-center py-4 text-2xl">MU作成</h1>
   <div class="flex flex-col mx-auto mb-4">

--- a/app/views/musics/show.html.erb
+++ b/app/views/musics/show.html.erb
@@ -32,8 +32,15 @@
       <p class="text-right">作成日時: <%= l @music.created_at, format: :long %></p>
     </div>
     <% if logged_in? && current_user.own?(@music) %>
-      <div class="text-right twitter link link-secondary">
-        <%= link_to "Xでシェア","https://twitter.com/share?url=#{music_url(@music)}&text=【STAY with MU】%0a#{@music.user.name} が育てた「#{@music.title}」  Lv. #{@music.level}を見て！&hashtags=STAYwithMU,MU", target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア" %>
+      <div class="flex justify-end">
+        <%= link_to "https://twitter.com/share?url=#{music_url(@music)}&text=【STAY with MU】%0a#{@music.user.name} が育てた「#{@music.title}」  Lv. #{@music.level}を見て！&hashtags=STAYwithMU,MU", target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア", class: "twitter btn btn-sm btn-outline" do %>
+          <div class="flex items-center">
+            <svg width="20" height="20" viewBox="0 0 1200 1227" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z" fill="white"/>
+            </svg>
+            でシェア
+          </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/musics/show.html.erb
+++ b/app/views/musics/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, @music.title) %>
+<% set_meta_tags title: @music.title %>
 <div class="container mx-auto">
   <div class="bg-base-300 py-5 px-3 rounded-lg">
     <div class="flex">

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <div class="flex justify-center items-center h-full">
   <%= form_with model: @user, url: password_reset_path(@token) do |f| %>
   <%= render 'shared/error_messages', object: f.object %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <div class="flex justify-center items-center h-full">
   <%= form_with url: password_resets_path do |f| %>
     <h1 class="mb-10 text-2xl">パスワードリセット申請</h1>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <h1 class="text-2xl sm:text-4xl text-center mb-8">プライバシーポリシー</h1>
 <div class="container py-8 px-10">
   <p class="mb-5">「STAY with MU」（以下，「本サイト」といいます。）は本ウェブサイト上で提供するサービス（以下,「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。</p>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <h1 class="text-4xl text-center mb-8">利用規約</h1>
 <div class="container py-8 px-10">
   <p class="mb-5">この利用規約（以下，「本規約」といいます。）は，「STAY with MU」（以下，「運営者」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -125,6 +125,6 @@
 <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
 <script>
 particlesJS.load('particles-js', './particlesjs.json', function() {
-      console.log('callback - particles.js loaded');
+      console.log('callback - particles.js config loaded');
     });
 </script>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <div class="flex justify-center items-center">
   <%= form_with model: @user, local: true do |f| %>
     <div class="p-5 bg-neutral rounded-xl max-w-lg">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <div class="flex flex-col justify-center items-center">
   <%= form_with model: @user, local: true do |f| %>
       <h1 class="mb-10 text-2xl">マイページ編集</h1>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% set_meta_tags title: t('.title') %>
 <div class="flex justify-center items-center mb-8">
   <div class="mt-7 p-5 bg-neutral rounded-xl max-w-lg">
     <%= form_with model: @user, local: true do |f| %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, @user.name) %>
+<% set_meta_tags title: @user.name %>
 <div class="container mx-auto">
   <div class="bg-base-300 py-5 px-3 rounded-lg">
     <div class="flex">

--- a/public/particlesjs.json
+++ b/public/particlesjs.json
@@ -1,20 +1,20 @@
 {
   "particles": {
     "number": {
-      "value": 356,
+      "value": 486,
       "density": {
         "enable": true,
         "value_area": 800
       }
     },
     "color": {
-      "value": "#a7b924"
+      "value": "#d8ff91"
     },
     "shape": {
       "type": "circle",
       "stroke": {
         "width": 0,
-        "color": "#000000"
+        "color": "#ffffff"
       },
       "polygon": {
         "nb_sides": 5
@@ -30,31 +30,31 @@
       "random": true,
       "anim": {
         "enable": true,
-        "speed": 1.0557003759917487,
-        "opacity_min": 0,
+        "speed": 1.6241544246026902,
+        "opacity_min": 0.1867777588293094,
         "sync": false
       }
     },
     "size": {
-      "value": 4.008530152163807,
+      "value": 3,
       "random": true,
       "anim": {
-        "enable": true,
-        "speed": 4.872463273808071,
+        "enable": false,
+        "speed": 4,
         "size_min": 0.3,
         "sync": false
       }
     },
     "line_linked": {
       "enable": false,
-      "distance": 150,
-      "color": "#a7b924",
-      "opacity": 0.4,
-      "width": 1
+      "distance": 112.2388442605866,
+      "color": "#79c30f",
+      "opacity": 0.43292125643369117,
+      "width": 0.6413648243462091
     },
     "move": {
       "enable": true,
-      "speed": 92.99789953020033,
+      "speed": 9.620472365193136,
       "direction": "none",
       "random": true,
       "straight": true,
@@ -72,30 +72,30 @@
     "events": {
       "onhover": {
         "enable": true,
-        "mode": "grab"
+        "mode": "bubble"
       },
       "onclick": {
-        "enable": false,
-        "mode": "repulse"
+        "enable": true,
+        "mode": "push"
       },
       "resize": true
     },
     "modes": {
       "grab": {
-        "distance": 400,
+        "distance": 292.34779642848423,
         "line_linked": {
           "opacity": 1
         }
       },
       "bubble": {
-        "distance": 250,
-        "size": 0,
-        "duration": 2,
-        "opacity": 0,
+        "distance": 182.71737276780266,
+        "size": 4.060386061506726,
+        "duration": 0.6496617698410762,
+        "opacity": 0.17865698670629593,
         "speed": 3
       },
       "repulse": {
-        "distance": 400,
+        "distance": 203.01930307533627,
         "duration": 0.4
       },
       "push": {


### PR DESCRIPTION
## 概要
以下の調整をした。
- スマホで入力するときの自動ズームを無効に
    - iOSの機能でフォームのフォントサイズが16px未満の場合にiOSの方で自動的にズームするようになっている。   maximum-scale=1.0を追加することで無効に。
- Xシェアボタンを変更 
- ページタイトルがリロードしないと反映しないバグを修正
    - content_forによるtitleの出力と、gem 'meta-tags'のヘルパーメソッドdefault_meta_tagsによるtitleの出力が重複していたことが原因。set_meta_tagsに統一。
- particles-jsの微調整

close #193 