### PR TITLE
コメント編集後のバグを修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,7 +21,7 @@ class CommentsController < ApplicationController
     @comment = Comment.find(params[:id])
     if @comment.update(params.require(:comment).permit(:body))
       flash[:success] = 'コメントを更新しました'
-      redirect_to music_path(comment.music)
+      redirect_to music_path(@comment.music)
     else
       flash.now[:error] = 'コメントの更新に失敗しました'
       render :edit, status: :unprocessable_entity


### PR DESCRIPTION
## 概要
コメント編集後にエラーになるバグを修正。
 https://github.com/ken55ty/stay_with_mu/pull/209 でcommentをインスタンス変数に変更した際に、リダイレクト先の変更が漏れていた。

close #218 