### PR TITLE
フラッシュメッセージのアニメーションを上にフェイドアウトするように変更

### DIFF
--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,22 +1,22 @@
 <% flash.each do |message_type, message| %>
   <% case message_type %>
   <% when "info"%>
-    <div role="alert" class="alert alert-info flex animate-slide-out-right">
+    <div role="alert" class="alert alert-info flex animate-slide-out-top">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
       <span><%= message %></span>
     </div>
   <% when "success" %>
-    <div role="alert" class="alert alert-success flex animate-slide-out-right">
+    <div role="alert" class="alert alert-success flex animate-slide-out-top">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
       <span><%= message %></span>
     </div>
   <% when "warnig" %>
-    <div role="alert" class="alert alert-warning flex animate-slide-out-right">
+    <div role="alert" class="alert alert-warning flex animate-slide-out-top">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
       <span><%= message %></span>
     </div>
   <% when "error" %>
-    <div role="alert" class="alert alert-error flex animate-slide-out-right">
+    <div role="alert" class="alert alert-error flex animate-slide-out-top">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
       <span><%= message %></span>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,8 +8,8 @@ module.exports = {
   theme: {
     extend: {
       animation: {
-        "focus-in-expand": "focus-in-expand 1.5s cubic-bezier(0.250, 0.460, 0.450, 0.940)   both",
-        "slide-out-right": "slide-out-right 0.5s cubic-bezier(0.550, 0.085, 0.680, 0.530) 5s both"
+        "focus-in-expand": "focus-in-expand 1.5s cubic-bezier(0.250, 0.460, 0.450, 0.940) both",
+        "slide-out-top": "slide-out-top 0.5s cubic-bezier(0.550, 0.085, 0.680, 0.530) 5s both"
       },
       keyframes: {
         "focus-in-expand": {
@@ -23,24 +23,23 @@ module.exports = {
             opacity: "1"
           }
         },
-        "slide-out-right": {
+        "slide-out-top": {
           "0%": {
-            transform: "translateX(0)",
+            transform: "translateY(0)",
             opacity: "1"
           },
           to: {
-            transform: "translateX(1000px)",
+            transform: "translateY(-1000px)",
             opacity: "0"
           }
         }
-      },
+      }
     }
   },
   plugins: [
     require('daisyui')
   ],
   daisyui: {
-    themes: ["night",],
+    themes: ["night"],
   },
-
 }


### PR DESCRIPTION
## 概要
フラッシュメッセージが右にフェイドアウトするアニメーションの後、右の画面幅が広がってしまっていた。
上にフェイドアウトするアニメーションに変更。

[![Image from Gyazo](https://i.gyazo.com/c54d0d715d9689c2211083d169a849c6.gif)](https://gyazo.com/c54d0d715d9689c2211083d169a849c6)

close #220 