### PR TITLE
MUの非公開機能

### DIFF
--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -64,6 +64,18 @@ class MusicsController < ApplicationController
     render partial: 'musics/autocompletes/index_autocomplete', locals: { musics: @musics, query: params[:q] }
   end
 
+  def publish
+    @music = current_user.musics.find(params[:id])
+    @music.update_columns(privacy: 0)
+    flash.now[:success] = '公開に変更しました'
+  end
+
+  def unpublish
+    @music = current_user.musics.find(params[:id])
+    @music.update_columns(privacy: 1)
+    flash.now[:success] = '非公開に変更しました'
+  end
+
   private
 
   def music_params

--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -4,7 +4,7 @@ class MusicsController < ApplicationController
   def index
     @q = Music.ransack(params[:q])
     @q.sorts = ['updated_at desc'] if params[:sorts].blank?
-    @musics = @q.result(distinct: true).includes(:user, memories: :tags).page(params[:page])
+    @musics = @q.result(distinct: true).includes(:user, memories: :tags).privacy_public.page(params[:page])
   end
 
   def search

--- a/app/controllers/musics_controller.rb
+++ b/app/controllers/musics_controller.rb
@@ -60,7 +60,7 @@ class MusicsController < ApplicationController
   end
 
   def index_autocomplete
-    @musics = Music.where('title ILIKE ? OR artist ILIKE ?', "%#{params[:q]}%", "%#{params[:q]}%").distinct.limit(10)
+    @musics = Music.where('title ILIKE ? OR artist ILIKE ?', "%#{params[:q]}%", "%#{params[:q]}%").privacy_public.distinct.limit(10)
     render partial: 'musics/autocompletes/index_autocomplete', locals: { musics: @musics, query: params[:q] }
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,9 +4,9 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @musics = @user.musics.includes(:user, :favorites, memories: :tags).order(updated_at: :desc).page(params[:page])
+    @musics = @user.musics.includes(:user, :favorites, memories: :tags).order(updated_at: :desc).visible_to(current_user).page(params[:page])
     @favorite_musics = @user.favorite_musics.includes(:user, :favorites,
-                                                      memories: :tags).order(updated_at: :desc).page(params[:page])
+                                                      memories: :tags).order(updated_at: :desc).visible_to(current_user).page(params[:page])
   end
 
   def new

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -7,6 +7,8 @@ class Music < ApplicationRecord
 
   validates :title, presence: true
 
+  enum privacy: { public: 0, private: 1 }, _prefix: true
+
   after_update :update_level
 
   private

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -9,6 +9,10 @@ class Music < ApplicationRecord
 
   enum privacy: { public: 0, private: 1 }, _prefix: true
 
+  scope :visible_to, ->(user) {
+    where(privacy: [:public]).or(where(user:, privacy: :private))
+  }
+
   after_update :update_level
 
   private

--- a/app/views/musics/_X_share.html.erb
+++ b/app/views/musics/_X_share.html.erb
@@ -1,0 +1,10 @@
+<div class="flex justify-end">
+  <%= link_to "https://twitter.com/share?url=#{music_url(music)}&text=【STAY with MU】%0a#{music.user.name} が育てた「#{music.title}」  Lv. #{music.level}を見て！&hashtags=STAYwithMU,MU", id: "X_share", target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア", class: "twitter btn btn-sm btn-outline" do %>
+    <div class="flex items-center">
+      <svg width="20" height="20" viewBox="0 0 1200 1227" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z" fill="white"/>
+      </svg>
+      でシェア
+    </div>
+  <% end %>
+</div>

--- a/app/views/musics/_music.html.erb
+++ b/app/views/musics/_music.html.erb
@@ -9,6 +9,13 @@
           <span class="mb-2"><%= "Lv. #{music.level}" %></span>
         </div>
       <% end %>
+
+      <% if logged_in? && current_user.own?(music) && music.privacy_private? %>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-lock-fill" viewBox="0 0 16 16">
+          <path d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2zm3 6V3a3 3 0 0 0-6 0v4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2z"/>
+        </svg>
+      <% end %>
+
       <div class="flex justify-end">
       <%= render 'musics/favorite_button', music: music %>
       </div>

--- a/app/views/musics/_privacy_toggle.html.erb
+++ b/app/views/musics/_privacy_toggle.html.erb
@@ -1,0 +1,5 @@
+<% if music.privacy_private? %>
+  <%= render "publish", music: music %>
+<% else %>
+  <%= render "musics/unpublish", music: music %>
+<% end %>

--- a/app/views/musics/_private_introduction.erb
+++ b/app/views/musics/_private_introduction.erb
@@ -1,0 +1,1 @@
+<p id="private_introduction" class="text-2xl text-error mb-4">このMUは非公開です</p>

--- a/app/views/musics/_publish.html.erb
+++ b/app/views/musics/_publish.html.erb
@@ -1,0 +1,6 @@
+<%= link_to publish_musics_path(:id => music.id), id: "publish-music-#{music.id}" , data: { turbo_stream: true, turbo_method: :post }, class: "btn btn-sm btn-outline" do %>
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-unlock-fill" viewBox="0 0 16 16">
+    <path d="M11 1a2 2 0 0 0-2 2v4a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h5V3a3 3 0 0 1 6 0v4a.5.5 0 0 1-1 0V3a2 2 0 0 0-2-2z"/>
+  </svg>
+  <p>公開する</p>
+<% end %>

--- a/app/views/musics/_search_result.html.erb
+++ b/app/views/musics/_search_result.html.erb
@@ -5,7 +5,7 @@
       <% musics.each do |music| %>
         <div class="p-1 my-2 border-radius">
           <iframe src="https://open.spotify.com/embed/track/<%= music.spotify_track_id %>" width="100%" height="80" frameborder="0" style="border-radius:12px" allowtransparency="true" allow="encrypted-media" loading="lazy"></iframe>
-          <%= form_with url: musics_path, data: { action: "submit->confirm#confirm", turbo: false, turbo_method: :post } do |form| %>
+          <%= form_with url: musics_path, model: music, data: { action: "submit->confirm#confirm", turbo: false, turbo_method: :post } do |form| %>
             <%= form.hidden_field :spotify_track_id, value: music.spotify_track_id %>
             <%= form.hidden_field :artist, value: music.artist %>
             <%= form.hidden_field :title, value: music.title %>

--- a/app/views/musics/_unpublish.html.erb
+++ b/app/views/musics/_unpublish.html.erb
@@ -1,0 +1,6 @@
+<%= link_to unpublish_musics_path(:id => music.id), id: "unpublish-music-#{music.id}", data: { turbo_stream: true, turbo_method: :post }, class: "btn btn-sm btn-outline" do %>
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-lock-fill" viewBox="0 0 16 16">
+    <path d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2zm3 6V3a3 3 0 0 0-6 0v4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2z"/>
+  </svg>
+  <p>非公開にする</p>
+<% end %>

--- a/app/views/musics/publish.turbo_stream.erb
+++ b/app/views/musics/publish.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_messages" %>
+
+<%= turbo_stream.replace "publish-music-#{@music.id}" do %>
+  <%= render "musics/unpublish", music: @music %>
+<% end %>
+
+<%= turbo_stream.remove "private_introduction" %>
+
+<%= turbo_stream.prepend "privacy_toggle" do %>
+  <%= render "X_share", music: @music %>
+<% end %>

--- a/app/views/musics/show.html.erb
+++ b/app/views/musics/show.html.erb
@@ -32,15 +32,13 @@
       <p class="text-right">作成日時: <%= l @music.created_at, format: :long %></p>
     </div>
     <% if logged_in? && current_user.own?(@music) %>
-      <div class="flex justify-end">
-        <%= link_to "https://twitter.com/share?url=#{music_url(@music)}&text=【STAY with MU】%0a#{@music.user.name} が育てた「#{@music.title}」  Lv. #{@music.level}を見て！&hashtags=STAYwithMU,MU", target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア", class: "twitter btn btn-sm btn-outline" do %>
-          <div class="flex items-center">
-            <svg width="20" height="20" viewBox="0 0 1200 1227" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z" fill="white"/>
-            </svg>
-            でシェア
-          </div>
-        <% end %>
+      <% if @music.privacy_private? %>
+        <%= render "private_introduction" %>
+      <% else %>
+        <%= render "X_share", music: @music %>
+      <% end %>
+      <div id="privacy_toggle">
+        <%= render "privacy_toggle", music: @music %>
       </div>
     <% end %>
   </div>

--- a/app/views/musics/unpublish.turbo_stream.erb
+++ b/app/views/musics/unpublish.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flash_messages" %>
+
+<%= turbo_stream.replace "unpublish-music-#{@music.id}" do %>
+  <%= render "musics/publish", music: @music %>
+<% end %>
+
+<%= turbo_stream.prepend "privacy_toggle" do %>
+  <%= render "private_introduction" %>
+<% end %>
+
+<%= turbo_stream.remove "X_share" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     collection do
       get :search
       get :index_autocomplete
+      post :publish
+      post :unpublish
     end
     resources :memories, only: %i[create edit update destroy], shallow: true
     resources :comments, only: %i[create edit update destroy], shallow: true

--- a/db/migrate/20240725062448_add_privacy_to_music.rb
+++ b/db/migrate/20240725062448_add_privacy_to_music.rb
@@ -1,0 +1,5 @@
+class AddPrivacyToMusic < ActiveRecord::Migration[7.1]
+  def change
+    add_column :musics, :privacy, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_09_155716) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_25_062448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_09_155716) do
     t.integer "favorites_count", default: 0, null: false
     t.integer "comments_count", default: 0, null: false
     t.integer "memories_count", default: 0, null: false
+    t.integer "privacy", default: 0, null: false
     t.index ["user_id"], name: "index_musics_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
MUを非公開に設定できるようにした。
## 内容
- MUの公開or非公開を切り替えられるようにした。
- 非公開に設定したMUはみんなのMU画面に表示されない。（作成者にも表示されないようにした。）
- 非公開に設定したMUは、ユーザー詳細画面のつくったMU・いいねしたMUに、ユーザー本人にのみ表示される。非公開のMUは鍵アイコン付きで表示される。
- 非公開設定はMU詳細画面から、作成者のみボタンで切り替えることができる。
- 非公開時には「このMUは非公開です」の文言が表示され、公開時にはXシェアボタンが表示される。これらはturbo_streamにより非同期で切り替えられる。
- 非公開のMUにURLでアクセスした場合は、みんなのMU画面にリダイレクトする。
- オートコンプリートで非公開のMUは候補にならないようにした。
## 備考
- 公開設定変更時にupdated_atが更新され、みんなのMUの一番上に来ないように、update_columnsで更新している。


close #222 