### PR TITLE
ユーザーが同じMUを複数作れないように設定

### DIFF
--- a/app/helpers/musics_helper.rb
+++ b/app/helpers/musics_helper.rb
@@ -45,8 +45,13 @@ module MusicsHelper
     end
   end
 
-  def link_to_playlist(music)
-    playlist = current_user.musics.find_by(spotify_track_id: music.spotify_track_id).playlists.first
-    link_to "プレイリストへ", playlist_path(playlist)
+  def display_link_to_music_or_playlist(music)
+    current_music = current_user.musics.find_by(spotify_track_id: music.spotify_track_id)
+    if current_music.privacy_playlist_only?
+      playlist = current_music.playlists.first
+      link_to "プレイリストへ", playlist_path(playlist), class: 'btn btn-sm btn-outline btn-success mt-2'
+    else
+      link_to "作成済みMUへ", music_path(current_music), class: 'btn btn-sm btn-outline btn-warning mt-2'
+    end
   end
 end

--- a/app/helpers/musics_helper.rb
+++ b/app/helpers/musics_helper.rb
@@ -44,4 +44,9 @@ module MusicsHelper
       end
     end
   end
+
+  def link_to_playlist(music)
+    playlist = current_user.musics.find_by(spotify_track_id: music.spotify_track_id).playlists.first
+    link_to "プレイリストへ", playlist_path(playlist)
+  end
 end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -19,7 +19,11 @@ class Music < ApplicationRecord
   after_update :update_level
 
   def created_by_user?(user)
-    user.musics.privacy_public.exists?(spotify_track_id: self.spotify_track_id)
+    user.musics.exists?(spotify_track_id: self.spotify_track_id)
+  end
+
+  def created_for_playlist(user)
+    user.musics.privacy_playlist_only.exists?(spotify_track_id: self.spotify_track_id)
   end
 
   def visible_to_user?(user)

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -22,10 +22,6 @@ class Music < ApplicationRecord
     user.musics.exists?(spotify_track_id: self.spotify_track_id)
   end
 
-  def created_for_playlist?(user)
-    user.musics.privacy_playlist_only.exists?(spotify_track_id: self.spotify_track_id)
-  end
-
   def visible_to_user?(user)
     Music.visible_to(user).exists?(id:)
   end

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -8,6 +8,7 @@ class Music < ApplicationRecord
   has_many :playlists, through: :playlist_musics
 
   validates :title, presence: true
+  validates :spotify_track_id, uniqueness: { scope: :user_id }
 
   enum privacy: { public: 0, private: 1, playlist_only: 2 }, _prefix: true
 

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -22,7 +22,7 @@ class Music < ApplicationRecord
     user.musics.exists?(spotify_track_id: self.spotify_track_id)
   end
 
-  def created_for_playlist(user)
+  def created_for_playlist?(user)
     user.musics.privacy_playlist_only.exists?(spotify_track_id: self.spotify_track_id)
   end
 

--- a/app/views/musics/_search_result.html.erb
+++ b/app/views/musics/_search_result.html.erb
@@ -9,7 +9,7 @@
             <%= form.hidden_field :spotify_track_id, value: music.spotify_track_id %>
             <%= form.hidden_field :artist, value: music.artist %>
             <%= form.hidden_field :title, value: music.title %>
-            <% if music.created_for_playlist(current_user) %>
+            <% if music.created_for_playlist?(current_user) %>
               <div class="btn btn-sm btn-success mt-2"><%= link_to_playlist(music) %></div>
             <% elsif music.created_by_user?(current_user) %>
               <div class="btn btn-sm btn-active btn-neutral mt-2">作成済みです</div>

--- a/app/views/musics/_search_result.html.erb
+++ b/app/views/musics/_search_result.html.erb
@@ -9,7 +9,13 @@
             <%= form.hidden_field :spotify_track_id, value: music.spotify_track_id %>
             <%= form.hidden_field :artist, value: music.artist %>
             <%= form.hidden_field :title, value: music.title %>
-            <%= form.submit 'MUをつくる！', class: "btn btn-sm btn-outline btn-primary mt-2" %>
+            <% if music.created_for_playlist(current_user) %>
+              <div class="btn btn-sm btn-success mt-2"><%= link_to_playlist(music) %></div>
+            <% elsif music.created_by_user?(current_user) %>
+              <div class="btn btn-sm btn-active btn-neutral mt-2">作成済みです</div>
+            <% else %>
+              <%= form.submit 'MUをつくる！', class: "btn btn-sm btn-outline btn-primary mt-2" %>
+            <% end %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/musics/_search_result.html.erb
+++ b/app/views/musics/_search_result.html.erb
@@ -9,10 +9,9 @@
             <%= form.hidden_field :spotify_track_id, value: music.spotify_track_id %>
             <%= form.hidden_field :artist, value: music.artist %>
             <%= form.hidden_field :title, value: music.title %>
-            <% if music.created_for_playlist?(current_user) %>
-              <div class="btn btn-sm btn-success mt-2"><%= link_to_playlist(music) %></div>
-            <% elsif music.created_by_user?(current_user) %>
-              <div class="btn btn-sm btn-active btn-neutral mt-2">作成済みです</div>
+
+            <% if music.created_by_user?(current_user) %>
+              <%= display_link_to_music_or_playlist(music) %>
             <% else %>
               <%= form.submit 'MUをつくる！', class: "btn btn-sm btn-outline btn-primary mt-2" %>
             <% end %>

--- a/db/migrate/20240902090145_add_index_to_musics_on_spotify_track_id_and_user_id.rb
+++ b/db/migrate/20240902090145_add_index_to_musics_on_spotify_track_id_and_user_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToMusicsOnSpotifyTrackIdAndUserId < ActiveRecord::Migration[7.1]
+  def change
+    add_index :musics, [:spotify_track_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_31_090606) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_02_090145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -83,6 +83,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_31_090606) do
     t.integer "comments_count", default: 0, null: false
     t.integer "memories_count", default: 0, null: false
     t.integer "privacy", default: 0, null: false
+    t.index ["spotify_track_id", "user_id"], name: "index_musics_on_spotify_track_id_and_user_id", unique: true
     t.index ["user_id"], name: "index_musics_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
ユーザーにつき同じ曲（同一のspotify_track_id）を複数MUとして作成できないよう変更。
## 内容
- musicsテーブルにuniquenessインデックスを追加し、ユーザーにつき同じ曲を 複数作れないように変更。
- uniquenessのバリデーション追加。
- MU作成時、作成済みのMUにはMU詳細へのリンク、プレイリスト専用で作成されているMUはプレイリスト詳細へのリンクが表示され、MU作成時にuniquenessのバリデーションにかかりMUが作られない状況を起こらないUIにした。
[![Image from Gyazo](https://i.gyazo.com/9029dd8d6e786f251f955cdc516ab037.png)](https://gyazo.com/9029dd8d6e786f251f955cdc516ab037)

close #230 