### PR TITLE
MUのレベルにプレイリストのbody文字数を反映

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -10,6 +10,7 @@ class MemoriesController < ApplicationController
   def create
     @memory = Memory.new(memory_params)
     if @memory.save
+      @memory.music.update_music_exp
       flash.now[:success] = 'メモリーを追加しました'
     else
       flash.now[:error] = 'メモリーを追加できませんでした'
@@ -19,6 +20,7 @@ class MemoriesController < ApplicationController
   def update
     @memory = Memory.find(params[:id])
     if @memory.update(params.require(:memory).permit(:body, :privacy, :recommended_topic_id, tag_ids: [])) # 汚いので改善したい。
+      @memory.music.update_music_exp
       flash[:success] = 'メモリーを更新しました'
       redirect_to music_path(@memory.music)
     else
@@ -30,6 +32,7 @@ class MemoriesController < ApplicationController
   def destroy
     @memory = Memory.find(params[:id])
     @memory.destroy!
+    @memory.music.update_music_exp
     flash.now[:success] = 'メモリーを削除しました'
   end
 

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -49,6 +49,7 @@ class PlaylistsController < ApplicationController
 
     if @playlist.save
       session.delete(:current_playlist_musics)
+      @playlist.musics.each(&:update_music_exp)
       flash[:success] = 'プレイリストを作成しました'
       redirect_to @playlist
     else

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -61,10 +61,7 @@ class PlaylistsController < ApplicationController
   def add_music_to_playlist
     @music = current_user.musics.build(music_params)
     session[:current_playlist_musics] ||= []
-    session[:current_playlist_musics].each do |music_params|
-      p music_params["spotify_track_id"]
-    end
-    session[:current_playlist_musics] << @music unless session[:current_playlist_musics].include?(@music.spotify_track_id)
+    session[:current_playlist_musics] << @music unless session[:current_playlist_musics].map { |music| music[:spotify_track_id] }.include?(@music.spotify_track_id)
   end
 
   def remove_music_from_playlist

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -10,8 +10,6 @@ class Memory < ApplicationRecord
 
   enum privacy: { public: 0, private: 1 }, _prefix: true
 
-  after_commit :update_music_exp
-
   private
 
   def validate_tag_count
@@ -19,15 +17,6 @@ class Memory < ApplicationRecord
     return unless tag_ids.count > max_tags
 
     errors.add(:base, "選択できるタグは#{max_tags}個までです")
-  end
-
-  def update_music_exp
-    return if music.frozen? # music削除に伴うmemory削除でコールバックした際にエラーにならないため追記
-
-    # musicに紐づくすべてのmemoryのbodyの文字数を合計
-    total_exp = music.memories.sum { |memory| memory.body.length }
-    # 合計値をmusicのexpとして保存
-    music.update(experience_point: total_exp)
   end
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/music.rb
+++ b/app/models/music.rb
@@ -16,7 +16,21 @@ class Music < ApplicationRecord
     where(privacy: [:public]).or(where(user:, privacy: :private))
   }
 
-  after_update :update_level
+  def update_music_exp
+    return if frozen?
+
+    total_exp = memories.sum { |memory| memory.body.length }
+
+    additional_exp_of_playlist = 100
+    total_exp += playlists.count * additional_exp_of_playlist
+
+    playlists.each do |playlist|
+      total_exp += playlist.body.length
+    end
+
+    update(experience_point: total_exp)
+    update_level
+  end
 
   def created_by_user?(user)
     user.musics.exists?(spotify_track_id: self.spotify_track_id)


### PR DESCRIPTION
## 概要
プレイリストに入っているMUにはプラスでレベルを上がるようにした。
## 内容
### 仕様について
- MUがユーザーが作成したプレイリストに含まれている場合、含まれるプレイリストの数につき100experience_point（レベル1~レベル11にレベルアップする相当）の経験値が加算される。
- 作成したプレイリストのメモリー（body）の文字数分のexperience_pointも加算される。
### 実装内容について備考
- 経験値更新ロジックをmemoryモデルにコールバックで書いていたが、musicモデルに移し、コールバックをやめ、各アクションで呼び出すようにした。
- プレイリスト作成時の重複を弾けていないバグを解消した。
close #225 