### PR TITLE
プレイリスト編集機能

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -13,8 +13,14 @@ class PlaylistsController < ApplicationController
     session[:current_playlist_musics] ||= []
     session[:current_playlist_musics].clear
     @music = Music.new
-    @musics = []
     @playlist = Playlist.new
+  end
+
+  def edit
+    @playlist = current_user.playlists.find(params[:id])
+    session[:current_playlist_musics] ||= []
+    session[:current_playlist_musics].clear
+    @playlist.musics.each { |music| session[:current_playlist_musics] << music }
   end
 
   def search

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -65,7 +65,34 @@ class PlaylistsController < ApplicationController
       redirect_to @playlist
     else
       flash.now[:error] = "プレイリストの作成に失敗しました"
-      render :new
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @playlist = current_user.playlists.find(params[:id])
+
+    if session[:current_playlist_musics].present?
+      session[:current_playlist_musics].each do |music_params|
+        music = Music.find_or_initialize_by(spotify_track_id: music_params["spotify_track_id"], user_id: current_user.id)
+        if music.new_record?
+          music.assign_attributes(music_params.slice("title", "artist", "experience_point", "level", "favorites_count", "comments_count", "memories_count"))
+          music.privacy_playlist_only!
+          music.save!
+        end
+
+        @playlist.musics << music unless @playlist.musics.include?(music)
+      end
+    end
+
+    if @playlist.update(playlist_params)
+      session.delete(:current_playlist_musics)
+      @playlist.musics.each(&:update_music_exp)
+      flash[:success] = 'プレイリストを更新しました'
+      redirect_to @playlist
+    else
+      flash.now[:error] = "プレイリストの更新に失敗しました"
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/views/musics/show.html.erb
+++ b/app/views/musics/show.html.erb
@@ -17,7 +17,7 @@
       <p class="text-2xl"><%=  @music.title %></p>
       <p class="text-lg"><%=  @music.artist %></p>
       <% @music.playlists.each do |playlist| %>
-        <p class="btn btn-sm btn-outline mx-1">
+        <p class="btn btn-sm btn-outline m-1">
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up-right" viewBox="0 0 16 16">
             <path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"/>
             <path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"/>

--- a/app/views/playlists/edit.html.erb
+++ b/app/views/playlists/edit.html.erb
@@ -1,0 +1,32 @@
+<% set_meta_tags title: t('.title') %>
+<h1 class="text-center py-4 text-2xl">プレイリスト編集</h1>
+<div class="flex flex-col sm:flex-row w-full">
+  <div class="flex w-full lg:w-1/2 xl:w-1/2 flex-col mx-auto mb-4">
+    <%= render 'playlists/search_form' %>
+    <% if @musics.present? %>
+      <%= render 'playlists/search_result', musics: @musics %>
+    <% end %>
+  </div>
+
+  <div class="flex flex-col w-full lg:w-1/2 xl:w-1/2">
+    <%= render 'playlists/preview', playlist: @playlist %>
+
+    <%= form_with model: @playlist, class: "flex flex-col items-center" do |f| %>
+      <div class="w-full text-center p-2">
+        <%= f.label :title, class: "text-lg font-bold text-primary" %>
+        <div class="flex justify-center items-center">
+          <%= f.text_field :title, required: true, placeholder: "タイトルは50文字まで", class: "input input-bordered input-sm sm:input-md bg-base-300 w-[16rem] sm:w-[32rem]", style: "width: 480px;" %>
+        </div>
+      </div>
+
+      <div class="w-full text-center p-2 mt-4">
+        <%= f.label :body, class: "text-lg font-bold text-primary" %>
+        <%= f.text_area :body, required: true, class: "auto-resize-textarea w-full h-24 my-2 bg-base-300 textarea textarea-bordered p-1 rounded-lg" %>
+      </div>
+
+      <div class="w-full p-2 mt-4 items-center">
+        <%= f.submit "プレイリストを更新", class: "btn btn-primary py-2 px-4" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -3,7 +3,9 @@
 <div class="flex flex-col sm:flex-row w-full">
   <div class="flex w-full lg:w-1/2 xl:w-1/2 flex-col mx-auto mb-4">
     <%= render 'playlists/search_form' %>
+    <% if @musics.present? %>
       <%= render 'playlists/search_result', musics: @musics %>
+    <% end %>
   </div>
 
   <div class="flex flex-col w-full lg:w-1/2 xl:w-1/2">

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -17,7 +17,8 @@
       <p class="text-lg"><%=  @playlist.body %></p>
 
     <% if logged_in? && current_user.own?(@playlist) %>
-      <%= link_to "削除", playlist_path(@playlist), data: { turbo_method: :delete, turbo_confirm: "本当にこのプレイリストを削除しますか？" }, class: "mb-2 btn btn-sm btn-error float-right"%>
+      <%= link_to "編集", edit_playlist_path(@playlist), class: "mb-2 btn btn-sm btn-secondary float-right" %>
+      <%= link_to "削除", playlist_path(@playlist), data: { turbo_method: :delete, turbo_confirm: "本当にこのプレイリストを削除しますか？" }, class: "mb-2 btn btn-sm btn-error float-right" %>
     <% end %>
 
     <div class="p-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     resources :memories, only: %i[create edit update destroy], shallow: true
     resources :comments, only: %i[create edit update destroy], shallow: true
   end
-  resources :playlists, only: %i[new create show index destroy] do
+  resources :playlists do
     collection do
       post :add_music_to_playlist
       get :search


### PR DESCRIPTION
## 概要
プレイリスト編集画面、更新機能を追加。
## 内容
編集するプレイリスト内のmusicをセッションに格納し、プレイリスト新規作成と同じ要領で更新アクションも実装した。

close #226 