### PR TITLE
プレイリストのバリデーションを追加

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -24,6 +24,7 @@ class PlaylistsController < ApplicationController
   end
 
   def search
+    @playlist = Playlist.new
     if params[:q].present?
       search_results = RSpotify::Track.search(params[:q])
       @musics = search_results.first(8).map do |track|
@@ -71,6 +72,7 @@ class PlaylistsController < ApplicationController
 
   def update
     @playlist = current_user.playlists.find(params[:id])
+    @playlist.musics.delete_all
 
     if session[:current_playlist_musics].present?
       session[:current_playlist_musics].each do |music_params|

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -3,6 +3,15 @@ class Playlist < ApplicationRecord
   has_many :playlist_musics, dependent: :destroy
   has_many :musics, through: :playlist_musics
 
-  validates :title, presence: true, length: { maximum: 50 }
+  validates :title, presence: true, length: { maximum: 100 }
   validates :body, presence: true, length: { maximum: 65_535 }
+  validate :validate_musics_count
+
+  def validate_musics_count
+    min_musics = 3
+    max_musics = 50
+    return if musics.size.between?(min_musics, max_musics)
+
+    errors.add(:base, "プレイリストに入れられる曲は#{min_musics}曲〜#{max_musics}曲です")
+  end
 end

--- a/app/views/playlists/edit.html.erb
+++ b/app/views/playlists/edit.html.erb
@@ -12,6 +12,7 @@
     <%= render 'playlists/preview', playlist: @playlist %>
 
     <%= form_with model: @playlist, class: "flex flex-col items-center" do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
       <div class="w-full text-center p-2">
         <%= f.label :title, class: "text-lg font-bold" %>
         <div class="flex justify-center items-center">

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -11,11 +11,12 @@
   <div class="flex flex-col w-full lg:w-1/2 xl:w-1/2">
     <%= render 'playlists/preview', playlist: @playlist %>
 
-    <%= form_with model: @playlist = Playlist.new, url: playlists_path, method: :post, class: "flex flex-col items-center" do |f| %>
+    <%= form_with model: @playlist, url: playlists_path, method: :post, scope: :playlist, class: "flex flex-col items-center" do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
       <div class="w-full text-center p-2">
         <%= f.label :title, class: "text-lg font-bold" %>
         <div class="flex justify-center items-center">
-          <%= f.text_field :title, required: true, placeholder: "タイトルは50文字まで", class: "input input-bordered input-sm sm:input-md bg-base-300 w-[16rem] sm:w-[32rem]", style: "width: 480px;" %>
+          <%= f.text_field :title, required: true, placeholder: "タイトルは100文字まで", class: "input input-bordered input-sm sm:input-md bg-base-300 w-[16rem] sm:w-[32rem]", style: "width: 480px;" %>
         </div>
       </div>
 


### PR DESCRIPTION
## 概要
プレイリストのバリデーションを追加。
## 内容
曲数：　3~50曲
タイトル：　50文字以内から100文字以内に変更。ツアー名、ライブ会場など収まらないため。
エラーメッセージを表示。

close #247 

