### PR TITLE
プレイリスト削除時に関連MUのレベル更新が行えていないバグを解消

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -100,9 +100,9 @@ class PlaylistsController < ApplicationController
 
   def destroy
     @playlist = current_user.playlists.find(params[:id])
+    playlist_musics = @playlist.musics.to_a
     @playlist.destroy!
-
-    @playlist.musics.each(&:update_music_exp)
+    playlist_musics.each(&:update_music_exp)
     flash.now[:success] = "プレイリストを削除しました"
     redirect_to playlists_path
   end


### PR DESCRIPTION
## 概要
プレイリスト削除時に関連MUのレベル更新が行えていないバグを解消。
## 内容
プレイリスト削除時にプレイリスト内MUの関連も消えてしまうため、配列で退避してからレベルを更新する。

close #236
