### PR TITLE
プレイリスト内の曲が、追加した順で固定されるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,8 @@ gem 'particles-js-rails', '2.0.0'
 
 gem 'activerecord-session_store'
 
+gem 'ranked-model'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
+    ranked-model (0.4.10)
+      activerecord (>= 5.2)
     ransack (4.1.1)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
@@ -495,6 +497,7 @@ DEPENDENCIES
   puma_worker_killer
   rails (~> 7.1.3, >= 7.1.3.2)
   rails-i18n
+  ranked-model
   ransack
   redis
   rinku

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -1,6 +1,6 @@
 class Playlist < ApplicationRecord
   belongs_to :user
-  has_many :playlist_musics, dependent: :destroy
+  has_many :playlist_musics, -> { rank(:row_order) }, dependent: :destroy, inverse_of: :playlist
   has_many :musics, through: :playlist_musics
 
   validates :title, presence: true, length: { maximum: 100 }

--- a/app/models/playlist_music.rb
+++ b/app/models/playlist_music.rb
@@ -1,4 +1,7 @@
 class PlaylistMusic < ApplicationRecord
+  include RankedModel
+  ranks :row_order, with_same: :playlist_id
+
   belongs_to :music
   belongs_to :playlist
 

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -3,6 +3,7 @@
 <div class="text-center my-4">
   <p>3~50曲のプレイリストを作成できます。</p>
   <p>MUをプレイリストに入れるとレベルが上がります。</p>
+  <p>追加した順番の曲順で保存されます。（曲順並び替え機能は作成中です）</p>
 </div>
 <div class="flex flex-col sm:flex-row w-full">
   <div class="flex w-full lg:w-1/2 xl:w-1/2 flex-col mx-auto mb-4">

--- a/db/migrate/20240917090321_add_row_order_to_playlist_musics.rb
+++ b/db/migrate/20240917090321_add_row_order_to_playlist_musics.rb
@@ -1,0 +1,6 @@
+class AddRowOrderToPlaylistMusics < ActiveRecord::Migration[7.1]
+  def change
+    add_column :playlist_musics, :row_order, :integer
+    PlaylistMusic.update_all('row_order = EXTRACT(EPOCH FROM created_at)')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_02_090145) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_17_090321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -105,6 +105,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_090145) do
     t.bigint "music_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "row_order"
     t.index ["music_id"], name: "index_playlist_musics_on_music_id"
     t.index ["playlist_id", "music_id"], name: "index_playlist_musics_on_playlist_id_and_music_id", unique: true
     t.index ["playlist_id"], name: "index_playlist_musics_on_playlist_id"


### PR DESCRIPTION
## 概要
gem 'ranked-model'をインストールし、プレイリストの曲の並びを追加した順番で固定されるようにする。
## 内容
- gem 'ranked-model'をインストール。
- playlist_musicsテーブルにrow_orderカラムを追加。

playlist_music.row_orderを一時的に表示した結果、プレイリストに追加した順番で数字が大きくなるようにrow_orderが振られ、昇順に表示されることを確認。
[![Image from Gyazo](https://i.gyazo.com/e7a4ce6f3c5d96ad787f879a02324c2a.png)](https://gyazo.com/e7a4ce6f3c5d96ad787f879a02324c2a)

close #228 