### PR TITLE
プレイリスト編集画面で楽曲検索するとプレイリスト作成画面に遷移してしまうバグの解消

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -23,7 +23,7 @@ class PlaylistsController < ApplicationController
     @playlist.musics.each { |music| session[:current_playlist_musics] << music }
   end
 
-  def search
+  def search_for_new
     @playlist = Playlist.new
     if params[:q].present?
       search_results = RSpotify::Track.search(params[:q])
@@ -41,6 +41,27 @@ class PlaylistsController < ApplicationController
     respond_to do |format|
       format.js { render partial: 'musics/autocompletes/new_autocomplete', locals: { musics: @musics } }
       format.html { render :new }
+    end
+  end
+
+  def search_for_edit
+    @playlist = current_user.playlists.find(params[:id])
+    if params[:q].present?
+      search_results = RSpotify::Track.search(params[:q])
+      @musics = search_results.first(8).map do |track|
+        Music.new(
+          spotify_track_id: track.id,
+          title: track.name,
+          artist: track.artists.first.name
+        )
+      end
+    else
+      @musics = []
+    end
+
+    respond_to do |format|
+      format.js { render partial: 'musics/autocompletes/new_autocomplete', locals: { musics: @musics } }
+      format.html { render :edit }
     end
   end
 

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -25,18 +25,7 @@ class PlaylistsController < ApplicationController
 
   def search_for_new
     @playlist = Playlist.new
-    if params[:q].present?
-      search_results = RSpotify::Track.search(params[:q])
-      @musics = search_results.first(8).map do |track|
-        Music.new(
-          spotify_track_id: track.id,
-          title: track.name,
-          artist: track.artists.first.name
-        )
-      end
-    else
-      @musics = []
-    end
+    @musics = search_tracks(params[:q])
 
     respond_to do |format|
       format.js { render partial: 'musics/autocompletes/new_autocomplete', locals: { musics: @musics } }
@@ -46,18 +35,7 @@ class PlaylistsController < ApplicationController
 
   def search_for_edit
     @playlist = current_user.playlists.find(params[:id])
-    if params[:q].present?
-      search_results = RSpotify::Track.search(params[:q])
-      @musics = search_results.first(8).map do |track|
-        Music.new(
-          spotify_track_id: track.id,
-          title: track.name,
-          artist: track.artists.first.name
-        )
-      end
-    else
-      @musics = []
-    end
+    @musics = search_tracks(params[:q])
 
     respond_to do |format|
       format.js { render partial: 'musics/autocompletes/new_autocomplete', locals: { musics: @musics } }
@@ -152,5 +130,17 @@ class PlaylistsController < ApplicationController
 
   def playlist_params
     params.require(:playlist).permit(:title, :body)
+  end
+
+  def search_tracks(query)
+    return [] if query.blank?
+
+    RSpotify::Track.search(query).first(8).map do |track|
+      Music.new(
+        spotify_track_id: track.id,
+        title: track.name,
+        artist: track.artists.first.name
+      )
+    end
   end
 end

--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_with model: playlist, url: form_url, method: form_method, scope: :playlist, class: "flex flex-col items-center" do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="w-full text-center p-2">
+    <%= f.label :title, class: "text-lg font-bold" %>
+    <div class="flex justify-center items-center">
+      <%= f.text_field :title, required: true, placeholder: "タイトルは100文字まで", class: "input input-bordered input-sm sm:input-md bg-base-300 w-[16rem] sm:w-[32rem]", style: "width: 480px;" %>
+    </div>
+  </div>
+
+  <div class="w-full text-center p-2 mt-4" data-controller="textarea">
+    <%= f.label :body, class: "text-lg font-bold" %>
+    <%= f.text_area :body, data: { textarea_target: "textarea" }, required: true, class: "w-full min-h-24 my-2 bg-base-300 textarea textarea-bordered p-1 rounded-lg" %>
+  </div>
+
+  <div class="w-full p-2 mt-4 flex justify-center items-center">
+    <%= f.submit submit_text, class: "btn btn-primary py-2 px-4" %>
+  </div>
+<% end %>

--- a/app/views/playlists/_search_form.html.erb
+++ b/app/views/playlists/_search_form.html.erb
@@ -1,6 +1,6 @@
 <div class="mx-auto">
   <div data-controller="autocomplete" data-autocomplete-url-value="/musics/search" role="combobox">
-    <%= form_with url: search_playlists_path, method: :get, html: { data: { turbo_frame: "playlist_search_results", turbo_action: :advance } }  do |f| %>
+    <%= form_with url: search_for_new_playlists_path, method: :get, html: { data: { turbo_frame: "playlist_search_results", turbo_action: :advance } }  do |f| %>
       <%= f.search_field :q, data: { autocomplete_target: "input" }, value: params[:q], class: "input input-bordered input-sm sm:input-md bg-base-300 w-[18rem] sm:w-[22rem]", placeholder: "曲名orアーティストで検索" %>
       <ul class="list-group bg-gray-200 rounded-md absolute w-full md:text-sm max-w-max z-50" data-autocomplete-target="results"></ul>
       <%= f.submit '検索', data: { action: "click->modal#checkClick" }, class: "btn btn-sm btn-primary ml-2" %>

--- a/app/views/playlists/_search_form.html.erb
+++ b/app/views/playlists/_search_form.html.erb
@@ -1,6 +1,6 @@
 <div class="mx-auto">
   <div data-controller="autocomplete" data-autocomplete-url-value="/musics/search" role="combobox">
-    <%= form_with url: search_for_new_playlists_path, method: :get, html: { data: { turbo_frame: "playlist_search_results", turbo_action: :advance } }  do |f| %>
+    <%= form_with url: url, method: :get, html: { data: { turbo_frame: "playlist_search_results", turbo_action: :advance } } do |f| %>
       <%= f.search_field :q, data: { autocomplete_target: "input" }, value: params[:q], class: "input input-bordered input-sm sm:input-md bg-base-300 w-[18rem] sm:w-[22rem]", placeholder: "曲名orアーティストで検索" %>
       <ul class="list-group bg-gray-200 rounded-md absolute w-full md:text-sm max-w-max z-50" data-autocomplete-target="results"></ul>
       <%= f.submit '検索', data: { action: "click->modal#checkClick" }, class: "btn btn-sm btn-primary ml-2" %>

--- a/app/views/playlists/edit.html.erb
+++ b/app/views/playlists/edit.html.erb
@@ -6,15 +6,7 @@
 </div>
 <div class="flex flex-col sm:flex-row w-full">
   <div class="flex w-full lg:w-1/2 xl:w-1/2 flex-col mx-auto mb-4">
-    <div class="mx-auto">
-      <div data-controller="autocomplete" data-autocomplete-url-value="/musics/search" role="combobox">
-        <%= form_with url: search_for_edit_playlist_path(@playlist), method: :get, html: { data: { turbo_frame: "playlist_search_results", turbo_action: :advance } }  do |f| %>
-          <%= f.search_field :q, data: { autocomplete_target: "input" }, value: params[:q], class: "input input-bordered input-sm sm:input-md bg-base-300 w-[18rem] sm:w-[22rem]", placeholder: "曲名orアーティストで検索" %>
-          <ul class="list-group bg-gray-200 rounded-md absolute w-full md:text-sm max-w-max z-50" data-autocomplete-target="results"></ul>
-          <%= f.submit '検索', data: { action: "click->modal#checkClick" }, class: "btn btn-sm btn-primary ml-2" %>
-        <% end %>
-      </div>
-    </div>
+    <%= render 'playlists/search_form', url: search_for_edit_playlist_path(@playlist) %>
     <% if @musics.present? %>
       <%= render 'playlists/search_result', musics: @musics %>
     <% end %>
@@ -22,24 +14,6 @@
 
   <div class="flex flex-col w-full lg:w-1/2 xl:w-1/2">
     <%= render 'playlists/preview', playlist: @playlist %>
-
-    <%= form_with model: @playlist, class: "flex flex-col items-center" do |f| %>
-      <%= render 'shared/error_messages', object: f.object %>
-      <div class="w-full text-center p-2">
-        <%= f.label :title, class: "text-lg font-bold" %>
-        <div class="flex justify-center items-center">
-          <%= f.text_field :title, required: true, placeholder: "タイトルは50文字まで", class: "input input-bordered input-sm sm:input-md bg-base-300 w-[16rem] sm:w-[32rem]", style: "width: 480px;" %>
-        </div>
-      </div>
-
-      <div class="w-full text-center p-2 mt-4" data-controller="textarea">
-        <%= f.label :body, class: "text-lg font-bold" %>
-        <%= f.text_area :body, data: { textarea_target: "textarea" }, required: true, class: "w-full min-h-24 my-2 bg-base-300 textarea textarea-bordered p-1 rounded-lg" %>
-      </div>
-
-      <div class="w-full p-2 mt-4 flex justify-center items-center">
-        <%= f.submit "プレイリストを更新", class: "btn btn-primary py-2 px-4" %>
-      </div>
-    <% end %>
+    <%= render 'playlists/form', playlist: @playlist, form_url: playlist_path(@playlist), form_method: :patch, submit_text: "プレイリストを更新" %>
   </div>
 </div>

--- a/app/views/playlists/edit.html.erb
+++ b/app/views/playlists/edit.html.erb
@@ -6,7 +6,15 @@
 </div>
 <div class="flex flex-col sm:flex-row w-full">
   <div class="flex w-full lg:w-1/2 xl:w-1/2 flex-col mx-auto mb-4">
-    <%= render 'playlists/search_form' %>
+    <div class="mx-auto">
+      <div data-controller="autocomplete" data-autocomplete-url-value="/musics/search" role="combobox">
+        <%= form_with url: search_for_edit_playlist_path(@playlist), method: :get, html: { data: { turbo_frame: "playlist_search_results", turbo_action: :advance } }  do |f| %>
+          <%= f.search_field :q, data: { autocomplete_target: "input" }, value: params[:q], class: "input input-bordered input-sm sm:input-md bg-base-300 w-[18rem] sm:w-[22rem]", placeholder: "曲名orアーティストで検索" %>
+          <ul class="list-group bg-gray-200 rounded-md absolute w-full md:text-sm max-w-max z-50" data-autocomplete-target="results"></ul>
+          <%= f.submit '検索', data: { action: "click->modal#checkClick" }, class: "btn btn-sm btn-primary ml-2" %>
+        <% end %>
+      </div>
+    </div>
     <% if @musics.present? %>
       <%= render 'playlists/search_result', musics: @musics %>
     <% end %>

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -7,7 +7,7 @@
 </div>
 <div class="flex flex-col sm:flex-row w-full">
   <div class="flex w-full lg:w-1/2 xl:w-1/2 flex-col mx-auto mb-4">
-    <%= render 'playlists/search_form' %>
+    <%= render 'playlists/search_form', url: search_for_new_playlists_path %>
     <% if @musics.present? %>
       <%= render 'playlists/search_result', musics: @musics %>
     <% end %>
@@ -15,24 +15,6 @@
 
   <div class="flex flex-col w-full lg:w-1/2 xl:w-1/2">
     <%= render 'playlists/preview', playlist: @playlist %>
-
-    <%= form_with model: @playlist, url: playlists_path, method: :post, scope: :playlist, class: "flex flex-col items-center" do |f| %>
-    <%= render 'shared/error_messages', object: f.object %>
-      <div class="w-full text-center p-2">
-        <%= f.label :title, class: "text-lg font-bold" %>
-        <div class="flex justify-center items-center">
-          <%= f.text_field :title, required: true, placeholder: "タイトルは100文字まで", class: "input input-bordered input-sm sm:input-md bg-base-300 w-[16rem] sm:w-[32rem]", style: "width: 480px;" %>
-        </div>
-      </div>
-
-      <div class="w-full text-center p-2 mt-4" data-controller="textarea">
-        <%= f.label :body, class: "text-lg font-bold" %>
-        <%= f.text_area :body, data: { textarea_target: "textarea" }, required: true, class: "w-full min-h-24 my-2 bg-base-300 textarea textarea-bordered p-1 rounded-lg" %>
-      </div>
-
-      <div class="w-full p-2 mt-4 flex justify-center items-center">
-        <%= f.submit "プレイリストをつくる!", class: "btn btn-primary py-2 px-4" %>
-      </div>
-    <% end %>
+    <%= render 'playlists/form', playlist: @playlist, form_url: playlists_path, form_method: :post, submit_text: "プレイリストをつくる!" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,10 +19,11 @@ Rails.application.routes.draw do
   resources :playlists do
     collection do
       post :add_music_to_playlist
-      get :search
+      get :search_for_new
     end
 
     member do
+      get :search_for_edit
       delete :remove_music_from_playlist
     end
   end


### PR DESCRIPTION
## 概要
プレイリスト編集画面で楽曲検索するとプレイリスト作成画面に遷移してしまうバグの解消
[![Image from Gyazo](https://i.gyazo.com/a3c864cc5706297ddf07eab874871cf4.gif)](https://gyazo.com/a3c864cc5706297ddf07eab874871cf4)
## 原因
プレイリスト編集画面の楽曲検索を、プレイリスト作成画面と同じsearchアクションを呼び出して使っていたが、render: newで新規登録用のテンプレートを表示していた。
編集画面用のsearchアクションはidを含める必要があるためmenberルーティングにする必要があり、アクションを分ける必要があった。
## 内容
- プレイリストの楽曲検索アクションをsearch_for_newアクションと、search_for_editアクションに分割
- viewおよびcontrollerの重複部分の整理

close #267
